### PR TITLE
Move SSR-only code into a subfolder

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
-  "presets": ["next/babel"]
+  "presets": [
+    "next/babel"
+  ],
+  "ignore": [
+    "src/pages/ssr/**"
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,9 @@
 {
+  "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
+  "plugins": [
+    "@typescript-eslint"
+  ],
   "extends": [
     "eslint:recommended",
     "plugin:compat/recommended",

--- a/package.json
+++ b/package.json
@@ -68,14 +68,14 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "defaults",
+      "current node"
     ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
-      "last 1 safari version"
+      "last 1 safari version",
+      "current node"
     ]
   }
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,34 @@
+import Document, { DocumentContext, DocumentInitialProps, Head, Html, Main, NextScript } from 'next/document'
+import React from 'react'
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+    const originalRenderPage = ctx.renderPage
+
+    ctx.renderPage = () => {
+      return originalRenderPage({
+        enhanceApp: (App) => App,
+        enhanceComponent: (Component) => Component,
+      })
+    }
+
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render(): React.ReactElement {
+    // noinspection HtmlRequiredTitleElement
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+// noinspection JSUnusedGlobalSymbols
+export default MyDocument

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { GetStaticProps, InferGetStaticPropsType } from 'next'
-import path from 'path'
-import fs from 'fs-extra'
+import { InferGetStaticPropsType } from 'next'
 import Link from 'next/link'
 import style from '../../articles.module.scss'
 import Footer from '../../footer'
-import sort_by from '../../sort_by'
 import Head from 'next/head'
+import { getStaticProps } from '../../ssr/articles'
+
+export { getStaticProps } from '../../ssr/articles'
 
 const BlogList: React.VoidFunctionComponent<InferGetStaticPropsType<typeof getStaticProps>> = ({ pages }) => {
   return (
@@ -36,26 +36,3 @@ const BlogList: React.VoidFunctionComponent<InferGetStaticPropsType<typeof getSt
 }
 
 export default BlogList
-
-export const getStaticProps: GetStaticProps<{ pages: { name: string; metadata: any }[] }> = async () => {
-  const ARTICLES_PATH = path.join(process.cwd(), 'src', 'pages', 'articles')
-  const items = await fs.readdir(ARTICLES_PATH)
-  const arr = []
-  for (let i = 0; i < items.length; i++) {
-    const filePath = path.join(ARTICLES_PATH, items[i])
-    const { ext, name } = path.parse(filePath)
-    // Only process markdown/mdx files that are not index.tsx pages
-    if (ext.startsWith('.md') && name !== 'index') {
-      const module = await import(`./${items[i]}`)
-      arr.push({ name, metadata: module.metadata })
-    }
-  }
-
-  sort_by(arr, (entry) => entry.metadata.title)
-
-  return {
-    props: {
-      pages: arr,
-    },
-  }
-}

--- a/src/sort_by.ts
+++ b/src/sort_by.ts
@@ -1,8 +1,6 @@
-type Comparable = number | string | [Comparable]
-
-const sort_by = <P>(array: P[], keyExtractor: (a: P) => Comparable): P[] =>
+const sort_by = <P, Q>(array: P[], keyExtractor: (a: P) => Q): P[] =>
   array
-    .map((entry): [Comparable, P] => [keyExtractor(entry), entry])
+    .map((entry): [Q, P] => [keyExtractor(entry), entry])
     .sort()
     .map(([_, entry]) => entry)
 

--- a/src/ssr/.browserslistrc
+++ b/src/ssr/.browserslistrc
@@ -1,0 +1,1 @@
+current node

--- a/src/ssr/.eslintrc.json
+++ b/src/ssr/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "jest": true,
+    "node": true
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/src/ssr/articles.tsx
+++ b/src/ssr/articles.tsx
@@ -1,0 +1,31 @@
+import { GetStaticProps } from 'next'
+import path from 'path'
+import fs from 'fs-extra'
+import sort_by from '../sort_by'
+
+type Page = { name: string; metadata: any }
+
+export const getStaticProps: GetStaticProps<{ pages: Page[] }> = async () => {
+  const ARTICLES_PATH = path.join(process.cwd(), 'src', 'pages', 'articles')
+  const items = await fs.readdir(ARTICLES_PATH)
+  const promises: Promise<Page[]>[] = items.map(async (item) => {
+    const filePath = path.join(ARTICLES_PATH, item)
+    const { ext, name } = path.parse(filePath)
+    // Only process markdown/mdx files that are not index.tsx pages
+    if (ext.startsWith('.md') && name !== 'index') {
+      const module = await import(`../pages/articles/${item}`)
+      return [{ name, metadata: module.metadata }]
+    }
+    return []
+  })
+
+  const entries: Page[] = (await Promise.all(promises)).flat(1)
+
+  const sorted: Page[] = sort_by(entries, (entry) => entry.metadata.title)
+
+  return {
+    props: {
+      pages: sorted,
+    },
+  }
+}


### PR DESCRIPTION
This allows me to lint code that will only run on the server for current node, while linting code that might run on the client for all supported browsers.