### PR TITLE
Limit parallelism for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,7 @@
     "enabled": true,
     "automerge": true,
     "automergeType": "branch"
-  }
+  },
+  "prConcurrentLimit": 2,
+  "branchConcurrentLimit": 4
 }


### PR DESCRIPTION
Vercel limits me to 100 deploys per day, and every rebase will trigger
another deploy.  So parallel branches are dangerous.