### PR TITLE
The middleware only needs to run on paths containing a capital letter

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,13 @@
+/* eslint-disable unicorn/prefer-string-raw */
 import { type NextRequest, NextResponse } from 'next/server';
 
-export function middleware(req: NextRequest): NextResponse {
+export const config = {
+  matcher: [
+    '/((?!api|_next/static|favicon.ico)[^A-Z]*[A-Z].*(?<!\\.(?:js|css)(?:\\.map)?)$)',
+  ],
+};
+
+export default function middleware(req: NextRequest): NextResponse {
   if (req.nextUrl.pathname === req.nextUrl.pathname.toLowerCase()) {
     return NextResponse.next();
   }


### PR DESCRIPTION
We can avoid running for Next's own paths, or for JS or CSS, and because we only lowercase we need there to be at least one upper-case letter present.

I'd use Unicode character classes, but it looks like Vercel's edge runtime doesn't support them.