### PR TITLE
Looks like Vercel doesn't support negative look-behind :(

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 export const config = {
   matcher: [
-    '/((?!api|_next/static|favicon.ico)[^A-Z]*[A-Z].*(?<!\\.(?:js|css)(?:\\.map)?)$)',
+    '/((?!api|_next/static|favicon.ico)[^A-Z]*[A-Z](?!.*\\.(?:js|css)(?:\\.map)?$).*)',
   ],
 };
 


### PR DESCRIPTION
The platform started responding with a 502 after successfully deploying.