### PR TITLE
Add a landing page for Home Assistant Desktop OAuth

### DIFF
--- a/src/app/oauth-redirect/page.tsx
+++ b/src/app/oauth-redirect/page.tsx
@@ -1,0 +1,38 @@
+import 'server-only';
+
+import React, { type ReactNode } from 'react';
+
+import { type Metadata } from 'next';
+
+import { PageStructure } from '@/components/PageStructure';
+
+export const metadata: Metadata = {
+  title: 'Home Assistant Desktop',
+  icons: {
+    other: {
+      rel: 'redirect_uri',
+      url: 'homeassistant://oauth-callback',
+    },
+  },
+};
+
+function Redirect(): ReactNode {
+  return (
+    <PageStructure
+      header={
+        <>
+          <h1 className="text-center">Home Assistant Desktop</h1>
+        </>
+      }
+      schemaType={''}
+      resource={''}
+    >
+      <p>
+        If you see this, it's probably because something has gone wrong with
+        logging into your Home Assistant instance.
+      </p>
+    </PageStructure>
+  );
+}
+
+export default Redirect;


### PR DESCRIPTION
This is (will be) a Tauri app, Home Assistant needs a suitable landing page to target OAuth.