### PR TITLE
Add project documentation and source-level JSDoc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,164 @@
+# AGENTS.md — aylett.co.uk
+
+Personal website for Andrew Aylett, hosted at https://www.aylett.co.uk/.
+
+## Tech Stack
+
+- **Framework:** Next.js 16 (App Router, React Server Components by default)
+- **Language:** TypeScript (strict)
+- **React:** 19 (with React Compiler enabled)
+- **Styling:** Tailwind CSS 4 via PostCSS
+- **Content:** Markdown files with YAML frontmatter, processed through unified
+- **Testing:** Jest 30 + Testing Library (jsdom)
+- **Linting:** ESLint 9 (flat config) + TypeScript type-checking
+- **Hosting:** Vercel (auto-deploy from main)
+- **Analytics:** Plausible (self-proxied)
+- **Node:** ^22
+
+## Directory Structure
+
+```
+src/
+  app/                    # Next.js App Router pages and routes
+    articles/
+      md/                 # Article markdown files
+      [id]/page.tsx       # Dynamic article route
+      articles.ts         # Data fetching (cached)
+      rss/                # RSS feed route
+    thoughts/
+      md/                 # Thought markdown files
+      [id]/page.tsx       # Dynamic thought route
+      thoughts.ts         # Data fetching (cached)
+      rss/                # RSS feed route
+    tags/                 # Tag listing and per-tag pages
+    card/                 # Business card page
+    qr/                   # QR code generator
+    links/                # Links page
+    schema/               # JSON-LD schema page
+    api/                  # API routes
+    layout.tsx            # Root layout
+    page.tsx              # Home page
+    sitemap.ts            # Dynamic sitemap generation
+    styles/               # Global CSS
+  client/                 # Client-side components (use "use client")
+    hooks/
+      useExploded.ts      # Proxy-based hook for lazy promise destructuring
+    mermaid/              # Dynamically imported Mermaid diagram renderer
+    qr/                   # QR code form component
+  components/             # Shared UI components (server-safe)
+  remark/                 # Unified markdown processing pipeline
+    process_markdown.ts   # Pipeline definitions (baseProcessor, intoReact, intoText)
+    traverse.ts           # Filesystem discovery and Markdown class
+    remarkRetextEnglish.ts # remark → retext bridge
+    retextRemark.ts       # retext → remark bridge
+    components.tsx        # rehype-react component overrides (Mermaid)
+  types.ts                # Content schemas and TypeFrom utility type
+  utilities.ts            # Shared helpers
+  proxy.ts                # Middleware: lowercase URL redirect
+test/                     # Jest test files (mirrors src/ structure)
+```
+
+## Architecture
+
+### App Router and RSC
+
+All pages are React Server Components unless explicitly marked `"use client"`.
+Client components live under `src/client/` and are dynamically imported where
+needed (e.g. Mermaid diagrams via `next/dynamic`).
+
+### Markdown Processing Pipeline
+
+The most complex custom code. Defined in `src/remark/process_markdown.ts`:
+
+1. **Parse:** `remark-parse` turns markdown into an mdast tree
+2. **Frontmatter extraction:** `remark-frontmatter` identifies YAML blocks,
+   then a custom `shiftIf` helper removes the first YAML node from the tree
+   and stores it on `vfile.data.frontMatter`
+3. **Text processing:** The mdast tree is bridged to nlcst via
+   `remarkRetextEnglish`, processed with `retext-smartypants` (smart quotes),
+   then bridged back to mdast via `retextRemark`
+4. **Dash conversion:** A custom visitor replaces ` -- ` with em-dashes
+5. **GFM:** GitHub-Flavoured Markdown extensions
+
+This base processor is then extended:
+- **`intoReact`**: Converts to hast via `remark-rehype`, strips redundant
+  `<pre>` wrappers around Mermaid code blocks, adds heading slugs, and renders
+  to React elements via `rehype-react` with custom component overrides
+- **`intoText`**: Serialises back to plain markdown via `remark-stringify`
+
+### Content System
+
+Two content types, each with a JSON Schema constant in `src/types.ts`:
+
+**Articles** (`ArticleSchema`):
+- Fields: title, revision, revised, author, expires, abstract, copyright,
+  description, lifecycle, tags
+- Lifecycle states: `draft`, `live`, `historical`, `obsolete` (default: `live`)
+- Located in `src/app/articles/md/`
+
+**Thoughts** (`ThoughtSchema`):
+- Fields: title, date, tags, description
+- No lifecycle tracking
+- Located in `src/app/thoughts/md/`
+
+Data fetching uses React's `cache()` wrapper around `findMarkdown()` for
+request-level deduplication (see `articles.ts` and `thoughts.ts`).
+
+### Type System
+
+`TypeFrom<Schema>` in `src/types.ts` recursively derives TypeScript types from
+JSON Schema constants at the type level. This means the schema constants serve
+as both runtime validators (via `assertSchema` + revalidator) and compile-time
+type sources — no separate interface definitions needed.
+
+### Key Patterns
+
+- **`use()` for promises:** Server components pass promises as props; client
+  components call React's `use()` to suspend until resolved.
+- **`useExploded`:** A Proxy-based hook that takes `Promise<{a, b}>` and
+  returns `{a: Promise<a>, b: Promise<b>}`, allowing individual fields to be
+  passed as props before the parent promise resolves.
+- **Dynamic imports:** The Mermaid renderer is loaded via `next/dynamic` with a
+  loading fallback to avoid bundling the large mermaid library on all pages.
+- **Middleware URL normalisation:** `src/proxy.ts` redirects any URL containing
+  uppercase characters to its lowercase equivalent.
+
+## Commands
+
+```sh
+npm run dev      # Start local dev server (next dev)
+npm run build    # Production build (next build --experimental-app-only)
+npm test         # Runs lint, then Jest
+npm run lint     # ESLint + TypeScript type-check (eslint && tsc -b .)
+npm run format   # Auto-fix: eslint --fix . && tsc -b .
+```
+
+## Testing
+
+- Test runner: Jest 30 with SWC transform
+- Environment: jsdom (via jest-environment-jsdom)
+- Test files: `test/` directory, mirroring `src/` structure
+  - `test/utilities.test.ts` — utility function tests
+  - `test/client/qr/QRCodeForm.test.tsx` — QR code form component tests
+  - `test/components/ListingEntry.test.tsx` — listing entry component tests
+- Libraries: `@testing-library/react`, `@testing-library/jest-dom`,
+  `@testing-library/user-event`
+- `npm test` runs `npm run lint` as a pretest step
+
+## Non-obvious Details
+
+- **CSP configuration:** `next.config.ts` sets strict Content-Security-Policy
+  headers in production (with `report-uri`). New external resources will be
+  blocked unless the CSP rules are updated.
+- **Mermaid dynamic import:** Mermaid is loaded client-side only via
+  `next/dynamic`. The `intoReact` pipeline also strips the `<pre>` wrapper
+  around mermaid code blocks so rehype-react can substitute the component.
+- **`shiftIf` frontmatter extraction:** Rather than using a standard frontmatter
+  plugin's built-in extraction, a custom `shiftIf` helper peels the first YAML
+  node from the tree. This allows the frontmatter to travel through the rest of
+  the pipeline on `vfile.data.frontMatter`.
+- **`pageExtensions`:** Set to `['js', 'jsx', 'ts', 'tsx']` in
+  `next.config.ts` — `.md` files are **not** page sources; they are read from
+  the filesystem by `traverse.ts`.
+- **React Compiler:** Enabled in `next.config.ts` (`reactCompiler: true`),
+  with the ESLint plugin for compiler-compatible code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+Personal website for Andrew Aylett (Next.js 16 / React 19 / TypeScript).
+
+See [AGENTS.md](./AGENTS.md) for project architecture, commands, and conventions.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,24 @@
 
 This is the source for the website hosted at https://www.aylett.co.uk/.
 
-It uses Typescript and Next.js, and deploys automatically to Vercel.
+It uses TypeScript and Next.js 16 with React 19, and deploys automatically to
+Vercel. Pages are server-rendered by default (RSC) to minimise client-side
+JavaScript.
 
-We use React 18 SSR to try to avoid needing to load code on the client.
+## Content
 
-Articles placed in `src/app/articles` with a `.md` extension will be picked up
-automatically. Please make sure to include a YAML block at the top of the
-document so that the rendering and listing code knows what to render and list.
-We default to a title matching the file name and Andrew being the author.
+- **Articles** (`src/app/articles/md/`) — longer-form pieces with revision
+  tracking and a lifecycle (draft, live, historical, obsolete).
+- **Thoughts** (`src/app/thoughts/md/`) — shorter posts with a date and tags.
+
+Both are written in Markdown with YAML frontmatter.
+
+## Development
+
+```sh
+npm run dev      # Start local dev server
+npm run build    # Production build
+npm test         # Lint + type-check + Jest tests
+npm run lint     # ESLint + TypeScript only
+npm run format   # Auto-fix lint issues
+```

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,3 +1,8 @@
+/**
+ * Next.js middleware that redirects URLs containing uppercase characters to their
+ * lowercase equivalent. The matcher regex excludes API routes, static files, and
+ * already-lowercase paths.
+ */
 /* eslint-disable unicorn/prefer-string-raw */
 import { type NextRequest, NextResponse } from 'next/server';
 

--- a/src/remark/components.tsx
+++ b/src/remark/components.tsx
@@ -1,3 +1,9 @@
+/**
+ * Custom component overrides for rehype-react.
+ *
+ * Intercepts `<code>` elements with `language-mermaid` class and renders them
+ * via a dynamically imported Mermaid client component instead.
+ */
 import React from 'react';
 
 import { type Components } from 'rehype-react';

--- a/src/remark/process_markdown.ts
+++ b/src/remark/process_markdown.ts
@@ -1,3 +1,12 @@
+/**
+ * Unified markdown processing pipeline.
+ *
+ * The pipeline has three stages:
+ * 1. Parse markdown and extract YAML frontmatter via `shiftIf`
+ * 2. Convert to natural language (retext) for smart-quote and dash processing,
+ *    then convert back to mdast
+ * 3. Convert to either React elements ({@link intoReact}) or plain text ({@link intoText})
+ */
 import { type Root, type Yaml } from 'mdast';
 import * as dev from 'react/jsx-dev-runtime';
 import * as prod from 'react/jsx-runtime';
@@ -37,6 +46,7 @@ function shiftIf<T>(array: T[], consumer: (val: T) => boolean): void {
   }
 }
 
+/** Shared base processor: parses markdown, extracts frontmatter, applies smartypants and dash conversion. */
 export const baseProcessor: Processor = unified()
   .use([
     // First we split off the frontmatter
@@ -75,6 +85,7 @@ const prodJsx = { Fragment: prod.Fragment, jsx: prod.jsx, jsxs: prod.jsxs };
 
 const devJsx = { jsxDEV: dev.jsxDEV };
 
+/** Extends base processor to produce React elements via rehype, with component overrides for Mermaid diagrams. */
 export const intoReact: Processor = baseProcessor()
   .use([
     remarkRehype,
@@ -128,6 +139,7 @@ export const intoReact: Processor = baseProcessor()
   ])
   .freeze();
 
+/** Extends base processor to serialize back to plain markdown text. */
 export const intoText: Processor = baseProcessor()
   .use([remarkStringify])
   .freeze();

--- a/src/remark/retextRemark.ts
+++ b/src/remark/retextRemark.ts
@@ -1,3 +1,10 @@
+/**
+ * Unified plugin that converts an nlcst (natural language) tree back to mdast (markdown).
+ *
+ * This is the inverse of `remarkRetextEnglish` — it re-parses the stringified
+ * nlcst back into markdown, preserving any micromark/mdast extensions registered
+ * on the processor.
+ */
 // noinspection JSUnusedGlobalSymbols
 
 import { type Root as MdastRoot } from 'mdast';

--- a/src/remark/traverse.ts
+++ b/src/remark/traverse.ts
@@ -1,3 +1,10 @@
+/**
+ * Filesystem traversal for markdown content.
+ *
+ * Discovers `.md` files under `src/app/<dir>`, processes them through the
+ * unified pipeline, and exposes parsed metadata and rendered React content
+ * as lazy promises via the {@link Markdown} class.
+ */
 import { readdir, stat } from 'node:fs/promises';
 import * as path from 'node:path';
 
@@ -32,6 +39,7 @@ async function findProjectDirectory(): Promise<string> {
   throw new Error(`Could not find project directory from ${process.cwd()}`);
 }
 
+/** Reads a directory under `src/app/` and returns all `.md` files with lazy-loaded vfile promises. */
 export async function traverse(dir: string): Promise<MDFile[]> {
   const app = path.resolve(await findProjectDirectory(), 'src/app');
   const target = path.join(app, dir);
@@ -80,6 +88,7 @@ async function extractResult(vfile: Promise<VFile>): Promise<ReactElement> {
   return (await vfile).result as ReactElement;
 }
 
+/** Wraps a markdown file with lazy promises for its rendered React content and validated frontmatter metadata. */
 export class Markdown<Schema extends JSONSchema7 & TaggedSchema> {
   constructor(mdFile: MDFile, schema: Schema) {
     this.id = mdFile.id;
@@ -93,6 +102,7 @@ export class Markdown<Schema extends JSONSchema7 & TaggedSchema> {
   metadata: Promise<TypeFrom<Schema>>;
 }
 
+/** Discovers and wraps all markdown files in a directory, validating each against the given schema. */
 export async function findMarkdown<T extends JSONSchema7 & TaggedSchema>(
   dir: string,
   schema: T,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Content schema definitions and runtime validation.
+ *
+ * Each content type (article, thought) has a JSON Schema constant that doubles
+ * as a TypeScript type source via {@link TypeFrom}. The `tag` field
+ * discriminates content types at runtime.
+ */
 import { type JSONSchema7 } from 'json-schema';
 import { validate } from 'revalidator';
 
@@ -15,6 +22,7 @@ export interface LifecycleSchema {
   };
 }
 
+/** JSON Schema for article frontmatter. Includes lifecycle states for content maturity. */
 export const ArticleSchema = {
   type: 'object',
   properties: {
@@ -37,6 +45,7 @@ export const ArticleSchema = {
 } as const satisfies JSONSchema7 & LifecycleSchema & TaggedSchema;
 export type ArticleSchema = typeof ArticleSchema;
 
+/** JSON Schema for thought frontmatter. Simpler than articles — no lifecycle or revision tracking. */
 export const ThoughtSchema = {
   type: 'object',
   properties: {
@@ -49,6 +58,10 @@ export const ThoughtSchema = {
 } as const satisfies JSONSchema7 & TaggedSchema;
 export type ThoughtSchema = typeof ThoughtSchema;
 
+/**
+ * Recursively derives a TypeScript type from a JSON Schema constant.
+ * Handles objects, strings (with enum narrowing), arrays, numbers, and the custom `tag` discriminator.
+ */
 export type TypeFrom<Schema> = Schema extends { tag: infer T }
   ? TypeFrom<Omit<Schema, 'tag'>> & { tag: T }
   : Schema extends {
@@ -66,6 +79,7 @@ export type TypeFrom<Schema> = Schema extends { tag: infer T }
           ? number
           : never;
 
+/** Validates `parsed` against a JSON Schema and asserts its type, throwing on validation or tag mismatch. */
 export function assertSchema<T extends JSONSchema7 & TaggedSchema>(
   parsed: unknown,
   schema: T,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,3 +1,4 @@
+/** Awaits a nullable promise and throws if the result is null. */
 export async function nullToError<T>(
   value: Promise<T | null>,
   message?: string,
@@ -23,12 +24,14 @@ export function encodeQueryComponent(component: string): string {
   });
 }
 
+/** Returns a GitHub URL pointing to the commit history for a given page's markdown source. */
 export const gitHubUrl = (pageName: string): string =>
   `https://github.com/andrewaylett/aylett.co.uk/commits/main/src/pages${pageName.replace(
     /#.*/,
     '',
   )}.md`;
 
+/** Sorts an array by an async-derived key, resolving all keys in parallel before sorting. */
 export async function asyncSortByKey<T, K>(
   input: T[],
   keyExtractor: (v: T) => PromiseLike<K>,


### PR DESCRIPTION
Add AGENTS.md with comprehensive project reference (architecture, markdown pipeline, content system, commands, testing, gotchas). Add CLAUDE.md stub pointing to AGENTS.md. Update README.md to fix React 18→19 and add dev commands and content type descriptions. Add JSDoc to utilities.ts, types.ts, process_markdown.ts, traverse.ts, retextRemark.ts, components.tsx, and proxy.ts.