### PR TITLE
Optimise for stable images over refresh

### DIFF
--- a/src/client/puzzles/friends/PuzzleView.tsx
+++ b/src/client/puzzles/friends/PuzzleView.tsx
@@ -50,7 +50,7 @@ export function PuzzleView({
   const submit = useCallback(() => {
     const w = input.trim().toUpperCase();
     if (!w) {
-      if (found.length === total) {
+      if (total > 0 && found.length === total) {
         newPuzzleAction();
       }
       return;
@@ -132,7 +132,6 @@ export function PuzzleView({
         >
           <div
             className={[
-              'mt-3.5',
               'bg-green-100',
               'dark:bg-green-900/40',
               'border',

--- a/src/components/Articles.tsx
+++ b/src/components/Articles.tsx
@@ -7,6 +7,8 @@ import { allArticles } from '@/app/articles/articles';
 import { sortByKey } from '@/utilities';
 
 export async function Articles(): Promise<JSX.Element> {
+  'use cache';
+
   const files = await allArticles();
   const pages = await Promise.all(
     files.map((f) => buildMetadata(f, ArticleSchema)),

--- a/src/components/BackgroundImage.tsx
+++ b/src/components/BackgroundImage.tsx
@@ -1,43 +1,40 @@
-'use client';
-
 import type { JSX } from 'react';
 
-import Image from 'next/image';
+import Image, { type StaticImageData } from 'next/image';
 
 import field from '../../public/PXL_20220610_201053680~2.jpg';
 import night from '../../public/PXL_20250407_202232580.NIGHT.jpg';
 
+function FullBackgroundImage({
+  src,
+  isDark,
+}: {
+  src: StaticImageData;
+  isDark: boolean;
+}): JSX.Element {
+  return (
+    <Image
+      src={src}
+      alt=""
+      sizes="calc(max(100vw, 133vh))"
+      className={
+        (isDark ? 'hidden dark:block' : 'block dark:hidden') +
+        ' object-cover h-full w-full inset-0'
+      }
+      loading="lazy"
+      fetchPriority="low"
+      style={{
+        background: `url("${src.blurDataURL}") fixed center / cover`,
+      }}
+    />
+  );
+}
+
 export function BackgroundImage(): JSX.Element {
   return (
-    <div className="fixed w-full h-full -z-50">
-      <Image
-        key="night"
-        src={night}
-        placeholder="blur"
-        alt=""
-        style={{
-          objectFit: 'cover',
-        }}
-        fill={true}
-        sizes="calc(max(100vw, 133vh))"
-        className="hidden dark:block"
-        loading="lazy"
-        fetchPriority="low"
-      />
-      <Image
-        key="day"
-        src={field}
-        placeholder="blur"
-        alt=""
-        style={{
-          objectFit: 'cover',
-        }}
-        fill={true}
-        sizes="calc(max(100vw, 133vh))"
-        className="block dark:hidden"
-        loading="lazy"
-        fetchPriority="low"
-      />
+    <div className="fixed w-full h-full -z-50" aria-hidden="true">
+      <FullBackgroundImage src={night} isDark={true} />
+      <FullBackgroundImage src={field} isDark={false} />
     </div>
   );
 }


### PR DESCRIPTION
Next's image management seems to want to show the blur placeholder on every mount, even if the image is already in cache, so it flickers from the full image to the blur and back again.  This might be sensible for small images, or where the image has transparency, but it's annoying when it's the full background and the image is already in cache.

The good news is that we can render the background statically and let the browser sort it out.