### PR TITLE
Require two anchor words with combined length ≥ 17

### DIFF
--- a/src/client/puzzles/friends/FoundWords.tsx
+++ b/src/client/puzzles/friends/FoundWords.tsx
@@ -11,7 +11,7 @@ export function FoundWords({
 }): JSX.Element {
   return (
     <div
-      className={`min-w-[20ch] h-full flex-1 bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-2xl p-4`}
+      className={`min-w-[22ch] h-full flex-1 bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-2xl p-4`}
     >
       <div className="flex justify-between items-baseline mb-2.5">
         <strong className="text-[0.95rem] text-blue-700 dark:text-blue-300">
@@ -27,21 +27,27 @@ export function FoundWords({
         </div>
       ) : (
         <ul className="list-none m-0 p-0 overflow-y-auto">
-          {[...found].reverse().map((w) => (
-            <li
-              key={w}
-              className={[
-                'animate-fade-in px-2 py-1.5 rounded-lg mb-1 text-[0.95rem] tracking-[0.06em]',
-                'flex justify-between',
-                w.length === maxLen
-                  ? 'bg-yellow-100 dark:bg-yellow-900/30'
-                  : 'bg-white/60 dark:bg-white/5',
-              ].join(' ')}
-            >
-              <span>{w}</span>
-              {w.length === maxLen && <span>★</span>}
-            </li>
-          ))}
+          {[...found].reverse().map((w) => {
+            const starCount = Math.max(0, 3 - (maxLen - w.length));
+            return (
+              <li
+                key={w}
+                className={[
+                  'animate-fade-in px-2 py-1.5 rounded-lg mb-1 text-[0.95rem] tracking-[0.06em]',
+                  'flex justify-between',
+                  w.length === maxLen
+                    ? 'bg-yellow-100 dark:bg-yellow-900/30'
+                    : 'bg-white/60 dark:bg-white/5',
+                ].join(' ')}
+              >
+                <span>{w}</span>
+                <span className="font-mono tabular-nums">
+                  {'⭒'.repeat(3 - starCount)}
+                  {'⭑'.repeat(starCount)}
+                </span>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/src/client/puzzles/friends/LineTraceWordGame.tsx
+++ b/src/client/puzzles/friends/LineTraceWordGame.tsx
@@ -33,6 +33,7 @@ const PuzzleSchema = z.object({
   edges: z.array(z.string()),
   words: z.record(z.string(), WordsValueSchema.optional()),
   seed: z.string(),
+  seed2: z.string(),
   critters: z.array(z.string()),
 });
 

--- a/src/client/puzzles/friends/gen/build-puzzle.ts
+++ b/src/client/puzzles/friends/gen/build-puzzle.ts
@@ -24,6 +24,7 @@ export interface Puzzle {
   edges: string[];
   words: WordsRecord;
   seed: string;
+  seed2: string;
   critters: string[];
 }
 
@@ -65,6 +66,7 @@ function pack(res: BuildResult): Puzzle {
     edges: [...res.edges],
     words,
     seed: res.seed,
+    seed2: res.seed2,
     critters: shuffle(CRITTERS).slice(0, 16),
   };
 }

--- a/src/client/puzzles/friends/gen/search-placement.ts
+++ b/src/client/puzzles/friends/gen/search-placement.ts
@@ -12,12 +12,14 @@ export interface Placement {
   fills: number;
 }
 
+const MAX_PLACEMENTS = 3;
+
 export function searchPlacement(
   word: string,
   grid: (string | null)[],
   edges: Set<string>,
-): Placement | null {
-  let best: Placement | null = null;
+): Placement[] {
+  const results: Placement[] = [];
   let nodes = 0;
   const L = word.length;
   const degAdj = Array.from<number>({ length: 16 }).fill(0);
@@ -35,9 +37,7 @@ export function searchPlacement(
     if (i === L) {
       if (fills > 0) {
         const score = L * 30 + fills * 60 + reuse * 12 - newE * 2;
-        if (!best || score > best.score) {
-          best = { path: [...path], score, fills };
-        }
+        results.push({ path: [...path], score, fills });
       }
       return;
     }
@@ -84,5 +84,6 @@ export function searchPlacement(
     }
     dfs(1, s, [s], g === null ? 1 : 0, 0, g === null ? 0 : 1);
   }
-  return best;
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, MAX_PLACEMENTS);
 }

--- a/src/client/puzzles/friends/gen/try-build.ts
+++ b/src/client/puzzles/friends/gen/try-build.ts
@@ -81,15 +81,15 @@ export async function tryBuild(seed: string): Promise<BuildResult | null> {
   );
   let seed2: string | null = null;
   for (const candidate of secondaryPool) {
-    const placement = searchPlacement(
+    const placements = searchPlacement(
       candidate,
       [...initialGrid],
       initialEdges,
     );
-    if (!placement) {
+    if (placements.length === 0) {
       continue;
     }
-    applyWord(candidate, placement.path, initialGrid, initialEdges);
+    applyWord(candidate, placements[0].path, initialGrid, initialEdges);
     seed2 = candidate;
     break;
   }
@@ -170,19 +170,21 @@ export async function tryBuild(seed: string): Promise<BuildResult | null> {
         if (usedWords.has(word)) {
           continue;
         }
-        const placement = searchPlacement(word, state.grid, state.edges);
-        if (!placement) {
+        const placements = searchPlacement(word, state.grid, state.edges);
+        if (placements.length === 0) {
           continue;
         }
         targetLen = len;
-        // Temp copy for scoring; produce would be wasteful here.
-        const tempGrid = [...state.grid];
-        const tempEdges = new Set(state.edges);
-        applyWord(word, placement.path, tempGrid, tempEdges);
-        const nextRemaining = remaining.filter((w) => w !== word);
-        const candidateScore =
-          wordsPlaced + 1 + countPotentialFit(tempGrid, nextRemaining);
-        candidates.push({ word, placement, candidateScore });
+        for (const placement of placements) {
+          // Temp copy for scoring; produce would be wasteful here.
+          const tempGrid = [...state.grid];
+          const tempEdges = new Set(state.edges);
+          applyWord(word, placement.path, tempGrid, tempEdges);
+          const nextRemaining = remaining.filter((w) => w !== word);
+          const candidateScore =
+            wordsPlaced + 1 + countPotentialFit(tempGrid, nextRemaining);
+          candidates.push({ word, placement, candidateScore });
+        }
       }
       if (targetLen !== null) {
         break;
@@ -194,8 +196,9 @@ export async function tryBuild(seed: string): Promise<BuildResult | null> {
     }
     candidates.sort((a, b) => b.candidateScore - a.candidateScore);
     const capturedLen = targetLen;
+    const MAX_BRANCH = 15;
 
-    for (const { word, placement } of candidates) {
+    for (const { word, placement } of candidates.slice(0, MAX_BRANCH)) {
       usedWords.add(word);
       const nextState = produce(state, (draft) => {
         applyWord(word, placement.path, draft.grid, draft.edges);

--- a/src/client/puzzles/friends/gen/try-build.ts
+++ b/src/client/puzzles/friends/gen/try-build.ts
@@ -10,7 +10,11 @@ import { boardContext } from '@/client/puzzles/friends/lexicon';
 import { placeSeedPath } from '@/client/puzzles/friends/gen/place-seed-path';
 import { applyWord } from '@/client/puzzles/friends/gen/apply-word';
 import { shuffle } from '@/client/puzzles/friends/helpers';
-import { FILLWORDS } from '@/client/puzzles/friends/words';
+import {
+  FILLWORDS,
+  SECONDARY_SEEDS,
+  shareRoot,
+} from '@/client/puzzles/friends/words';
 import {
   type Placement,
   searchPlacement,
@@ -23,6 +27,7 @@ export interface BuildResult {
   edges: Set<string>;
   accepted: Map<string, WordInfo>;
   seed: string;
+  seed2: string;
 }
 
 interface DfsState {
@@ -70,6 +75,29 @@ export async function tryBuild(seed: string): Promise<BuildResult | null> {
   }
   applyWord(seed, seedPath, initialGrid, initialEdges);
 
+  // Place a second anchor word (length ≥ 8, different root from seed1).
+  const secondaryPool = shuffle(
+    SECONDARY_SEEDS.filter((w) => w !== seed && !shareRoot(seed, w)),
+  );
+  let seed2: string | null = null;
+  for (const candidate of secondaryPool) {
+    const placement = searchPlacement(
+      candidate,
+      [...initialGrid],
+      initialEdges,
+    );
+    if (!placement) {
+      continue;
+    }
+    applyWord(candidate, placement.path, initialGrid, initialEdges);
+    seed2 = candidate;
+    break;
+  }
+  if (!seed2) {
+    return null;
+  }
+  const seed2Word = seed2;
+
   const shuffled = shuffle(FILLWORDS);
   const allLens = [9, 8, 7, 6, 5, 4] as const;
   const wordsByLen = new Map<number, string[]>();
@@ -83,7 +111,8 @@ export async function tryBuild(seed: string): Promise<BuildResult | null> {
 
   let bestResult: BuildResult | null = null;
   let bestScore = -Infinity;
-  const usedWords = new Set<string>();
+  // Exclude both seeds from fill DFS so they can't be re-placed.
+  const usedWords = new Set<string>([seed, seed2Word]);
 
   const dfs = async (state: DfsState, wordsPlaced: number): Promise<void> => {
     const remaining = FILLWORDS.filter(
@@ -109,12 +138,18 @@ export async function tryBuild(seed: string): Promise<BuildResult | null> {
       const ctx = await boardContext(filledGrid);
       enrich(filledGrid, edges, ctx);
       const accepted = scanWords(filledGrid, edges, ctx);
-      if (!accepted.has(seed)) {
+      if (!accepted.has(seed) || !accepted.has(seed2Word)) {
         return;
       }
       if (upperBound > bestScore) {
         bestScore = upperBound;
-        bestResult = { grid: filledGrid, edges, accepted, seed };
+        bestResult = {
+          grid: filledGrid,
+          edges,
+          accepted,
+          seed,
+          seed2: seed2Word,
+        };
       }
       return;
     }

--- a/src/client/puzzles/friends/words/index.ts
+++ b/src/client/puzzles/friends/words/index.ts
@@ -66,17 +66,54 @@ function expandList(raw: string): Set<string> {
   return out;
 }
 
+function expandListWithRoots(raw: string): {
+  words: Set<string>;
+  roots: Map<string, string>;
+} {
+  const words = new Set<string>();
+  const roots = new Map<string, string>();
+  for (const token of raw.split(/\s+/)) {
+    if (!token) {
+      continue;
+    }
+    const [base, flags = ''] = token.split('/');
+    if (!/^[a-z]+$/.test(base)) {
+      continue;
+    }
+    const upperBase = base.toUpperCase();
+    for (const w of inflect(base, flags)) {
+      if (w.length >= 4) {
+        const upper = w.toUpperCase();
+        words.add(upper);
+        roots.set(upper, upperBase);
+      }
+    }
+  }
+  return { words, roots };
+}
+
 export const AVOID: Set<string> = expandList(RAW_AVOID);
-const COMMON = new Set(
-  [...expandList(RAW_COMMON)].filter((w) => !AVOID.has(w)),
+const { words: COMMON_RAW, roots: COMMON_ROOTS } =
+  expandListWithRoots(RAW_COMMON);
+const COMMON = new Set([...COMMON_RAW].filter((w) => !AVOID.has(w)));
+export const WORD_ROOTS: ReadonlyMap<string, string> = new Map(
+  [...COMMON_ROOTS.entries()].filter(([w]) => COMMON.has(w)),
 );
+export function shareRoot(w1: string, w2: string): boolean {
+  const r1 = WORD_ROOTS.get(w1);
+  const r2 = WORD_ROOTS.get(w2);
+  return r1 !== undefined && r2 !== undefined && r1 === r2;
+}
 export const DEFAULT_WORDS: string[] = [
   ...new Set(
     [...COMMON, ...expandList(RAW_EXTRA)].filter((w) => !AVOID.has(w)),
   ),
 ].sort();
 export const SEEDS: string[] = [...COMMON].filter(
-  (w) => w.length >= 11 && w.length <= 14,
+  (w) => w.length >= 9 && w.length <= 14,
+);
+export const SECONDARY_SEEDS: string[] = [...COMMON].filter(
+  (w) => w.length >= 8 && w.length <= 14,
 );
 export const FILLWORDS: string[] = [...COMMON].filter(
   (w) => w.length >= 4 && w.length <= 9,

--- a/test/client/puzzles/friends/gen/search-placement.test.ts
+++ b/test/client/puzzles/friends/gen/search-placement.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, expect, it } from '@jest/globals';
 
 import { searchPlacement } from '@/client/puzzles/friends/gen/search-placement';
@@ -9,39 +8,39 @@ function emptyGrid(): (string | null)[] {
 }
 
 describe('searchPlacement', () => {
-  it('returns null when no placement exists', () => {
+  it('returns empty array when no placement exists', () => {
     // Fully-filled grid whose letters cannot match the word at all.
     const grid: (string | null)[] = Array.from({ length: 16 }, () => 'z');
     const result = searchPlacement('abcd', grid, new Set());
-    expect(result).toBeNull();
+    expect(result).toHaveLength(0);
   });
 
-  it('returns a Placement with correct path length for a word on an empty grid', () => {
-    const result = searchPlacement('cats', emptyGrid(), new Set());
-    expect(result).not.toBeNull();
-    expect(result?.path).toHaveLength(4);
+  it('returns at least one Placement with correct path length for a word on an empty grid', () => {
+    const results = searchPlacement('cats', emptyGrid(), new Set());
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].path).toHaveLength(4);
   });
 
   it('returned path has all unique cells', () => {
-    const result = searchPlacement('dogs', emptyGrid(), new Set());
-    expect(result).not.toBeNull();
-    const path = result!.path;
+    const results = searchPlacement('dogs', emptyGrid(), new Set());
+    expect(results.length).toBeGreaterThan(0);
+    const path = results[0].path;
     expect(new Set(path).size).toBe(path.length);
   });
 
   it('returned path has every consecutive pair adjacent in NEIGH', () => {
-    const result = searchPlacement('fish', emptyGrid(), new Set());
-    expect(result).not.toBeNull();
-    const path = result!.path;
+    const results = searchPlacement('fish', emptyGrid(), new Set());
+    expect(results.length).toBeGreaterThan(0);
+    const path = results[0].path;
     for (let i = 0; i < path.length - 1; i++) {
       expect(NEIGH[path[i]]).toContain(path[i + 1]);
     }
   });
 
   it('fills > 0 is enforced (all-null grid means all cells are new fills)', () => {
-    const result = searchPlacement('cats', emptyGrid(), new Set());
-    expect(result).not.toBeNull();
-    expect(result!.fills).toBeGreaterThan(0);
+    const results = searchPlacement('cats', emptyGrid(), new Set());
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].fills).toBeGreaterThan(0);
   });
 
   it('fills equals the number of null cells in the path', () => {
@@ -49,9 +48,21 @@ describe('searchPlacement', () => {
     // A placement starting at 0 and continuing to three null cells gives fills=3.
     const grid = emptyGrid();
     grid[0] = 'c';
-    const result = searchPlacement('cats', grid, new Set());
-    expect(result).not.toBeNull();
-    const nullsInPath = result!.path.filter((c) => grid[c] === null).length;
-    expect(result!.fills).toBe(nullsInPath);
+    const results = searchPlacement('cats', grid, new Set());
+    expect(results.length).toBeGreaterThan(0);
+    const nullsInPath = results[0].path.filter((c) => grid[c] === null).length;
+    expect(results[0].fills).toBe(nullsInPath);
+  });
+
+  it('returns results sorted by score descending', () => {
+    const results = searchPlacement('cats', emptyGrid(), new Set());
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+    }
+  });
+
+  it('returns at most MAX_PLACEMENTS results', () => {
+    const results = searchPlacement('cats', emptyGrid(), new Set());
+    expect(results.length).toBeLessThanOrEqual(3);
   });
 });


### PR DESCRIPTION
Place a second seed word (length ≥ 8) after the primary seed (length ≥ 9)
before running the fill DFS. The two anchors must not share an inflectional
root, preventing pairs like WALK/WALKING. The minimum-length constraints
guarantee combined length ≥ 17.

- words/index.ts: add expandListWithRoots, WORD_ROOTS, shareRoot,
  SECONDARY_SEEDS; relax SEEDS lower bound from 11 to 9
- gen/try-build.ts: find and place seed2 via searchPlacement, pre-populate
  usedWords with both seeds, require accepted.has(seed2) at leaf nodes
- gen/build-puzzle.ts: add seed2 to Puzzle interface and pack()
- LineTraceWordGame.tsx: add seed2 to PuzzleSchema