### PR TITLE
Bound-and-prune + top-K optimisation for searchPlacement

### DIFF
--- a/src/client/puzzles/friends/gen/search-placement.ts
+++ b/src/client/puzzles/friends/gen/search-placement.ts
@@ -14,6 +14,32 @@ export interface Placement {
 
 const MAX_PLACEMENTS = 3;
 
+/**
+ * Upper bound on the score of any completion reachable from a DFS node that
+ * has taken `i` of `L` steps with the given running totals.
+ *
+ * The leaf score is `L*30 + fills*60 + reuse*12 - newE*2`, and `fills`,
+ * `reuse`, `newE` only ever increase as the path extends. Each remaining
+ * step falls into one of three cases: fill+new-edge (Δscore 58), reuse+new-
+ * edge (Δscore 10), or reuse+reused-edge (Δscore 24). A fourth combination,
+ * "fill + reused edge", is arithmetically possible (Δscore 72) but cannot
+ * occur: `applyWord` (apply-word.ts) only ever adds an edge to `edges` in
+ * the same step that assigns letters to both of that edge's endpoints, and
+ * `grid` cells are never reset back to `null` once filled — so
+ * `grid[nb] === null` (a fill) always implies the edge to `nb` is not yet in
+ * `edges` (a new edge). The true per-step maximum is therefore 58, not 72,
+ * giving a materially tighter bound.
+ */
+export function upperBoundScore(
+  L: number,
+  i: number,
+  fills: number,
+  reuse: number,
+  newE: number,
+): number {
+  return L * 30 + fills * 60 + reuse * 12 - newE * 2 + 58 * (L - i);
+}
+
 export function searchPlacement(
   word: string,
   grid: (string | null)[],
@@ -23,6 +49,18 @@ export function searchPlacement(
   let nodes = 0;
   const L = word.length;
   const degAdj = Array.from<number>({ length: 16 }).fill(0);
+  const insertResult = (p: Placement): void => {
+    let idx = results.findIndex((r) => r.score < p.score);
+    if (idx === -1) {
+      idx = results.length;
+    }
+    if (idx < MAX_PLACEMENTS) {
+      results.splice(idx, 0, p);
+      if (results.length > MAX_PLACEMENTS) {
+        results.pop();
+      }
+    }
+  };
   const dfs = (
     i: number,
     cell: number,
@@ -34,10 +72,17 @@ export function searchPlacement(
     if (nodes++ > 6000) {
       return;
     }
+    if (
+      results.length === MAX_PLACEMENTS &&
+      upperBoundScore(L, i, fills, reuse, newE) <=
+        results[MAX_PLACEMENTS - 1].score
+    ) {
+      return;
+    }
     if (i === L) {
       if (fills > 0) {
         const score = L * 30 + fills * 60 + reuse * 12 - newE * 2;
-        results.push({ path: [...path], score, fills });
+        insertResult({ path: [...path], score, fills });
       }
       return;
     }
@@ -84,6 +129,5 @@ export function searchPlacement(
     }
     dfs(1, s, [s], g === null ? 1 : 0, 0, g === null ? 0 : 1);
   }
-  results.sort((a, b) => b.score - a.score);
-  return results.slice(0, MAX_PLACEMENTS);
+  return results;
 }

--- a/test/client/puzzles/friends/gen/search-placement.test.ts
+++ b/test/client/puzzles/friends/gen/search-placement.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { searchPlacement } from '@/client/puzzles/friends/gen/search-placement';
-import { NEIGH } from '@/client/puzzles/friends/helpers';
+import {
+  searchPlacement,
+  upperBoundScore,
+} from '@/client/puzzles/friends/gen/search-placement';
+import { ekey, NEIGH } from '@/client/puzzles/friends/helpers';
 
 function emptyGrid(): (string | null)[] {
   return Array.from({ length: 16 }, () => null);
@@ -64,5 +67,98 @@ describe('searchPlacement', () => {
   it('returns at most MAX_PLACEMENTS results', () => {
     const results = searchPlacement('cats', emptyGrid(), new Set());
     expect(results.length).toBeLessThanOrEqual(3);
+  });
+
+  // Regression test for the bound-and-prune + incremental top-K
+  // optimisation. The DFS explores every neighbour of every cell regardless
+  // of `shuffle`'s order — shuffle only changes iteration order, not the set
+  // explored — so for a case comfortably under the 6000-node cap, the set of
+  // reachable leaf scores (and therefore the top-K scores) is deterministic
+  // even though path selection among ties is not. This grid has 13 reachable
+  // placements of 'cats' (well past MAX_PLACEMENTS), so pruning genuinely
+  // engages rather than merely finding all results before the cap is hit —
+  // an earlier version of this test used a grid with only 3 total
+  // placements, under which pruning never activates before the search ends,
+  // so it couldn't have caught an over-aggressive threshold (e.g. comparing
+  // against the *best* kept score instead of the *worst*). The three
+  // expected scores below are verified by hand against the leaf-score
+  // formula (see upperBoundScore's doc comment) for paths [1,4,9,13],
+  // [9,4,0,1] and [1,4,8,9] respectively.
+  it('characterization: exact top-K scores where pruning must discriminate among many candidates', () => {
+    const grid: (string | null)[] = [
+      't',
+      null,
+      'z',
+      'z',
+      'a',
+      's',
+      'z',
+      'z',
+      't',
+      null,
+      'z',
+      null,
+      'z',
+      null,
+      'z',
+      null,
+    ];
+    const edges = new Set([ekey('0', '4')]);
+    const results = searchPlacement('cats', grid, edges);
+    expect(results.map((r) => r.score)).toEqual([306, 272, 258]);
+  });
+
+  it('scenario: partially-filled grid exercises reuse and mixed fill contributions', () => {
+    // Pre-fills two adjacent cells and their connecting edge, so completions
+    // exercise both letter-reuse and edge-reuse alongside fresh fills,
+    // giving the pruning bound a non-trivial (non-uniform) score landscape
+    // to cut against.
+    const grid = emptyGrid();
+    grid[0] = 'c';
+    grid[1] = 'a';
+    const edges = new Set([ekey('0', '1')]);
+    const results = searchPlacement('cat', grid, edges);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.length).toBeLessThanOrEqual(3);
+    for (const r of results) {
+      expect(r.fills).toBeGreaterThan(0);
+    }
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+    }
+  });
+
+  describe('upperBoundScore', () => {
+    it('equals the exact leaf formula when i === L', () => {
+      const L = 4;
+      const fills = 3;
+      const reuse = 1;
+      const newE = 3;
+      const leafScore = L * 30 + fills * 60 + reuse * 12 - newE * 2;
+      expect(upperBoundScore(L, L, fills, reuse, newE)).toBe(leafScore);
+    });
+
+    it('is non-increasing as i advances toward L for fixed running totals', () => {
+      const L = 5;
+      const fills = 2;
+      const reuse = 1;
+      const newE = 1;
+      let previous = upperBoundScore(L, 0, fills, reuse, newE);
+      for (let i = 1; i <= L; i++) {
+        const current = upperBoundScore(L, i, fills, reuse, newE);
+        expect(current).toBeLessThanOrEqual(previous);
+        previous = current;
+      }
+    });
+
+    it('matches a hand-computed bound for an empty-grid first step', () => {
+      // L=3, one step taken (a fill, no edge yet): 3*30 + 1*60 + 58*(3-1).
+      expect(upperBoundScore(3, 1, 1, 0, 0)).toBe(266);
+    });
+
+    it('matches a hand-computed bound with reuse and newE present', () => {
+      // L=4, i=2, fills=1, reuse=1, newE=1: 4*30 + 1*60 + 1*12 - 1*2 + 58*2.
+      expect(upperBoundScore(4, 2, 1, 1, 1)).toBe(306);
+    });
   });
 });


### PR DESCRIPTION
Compute an upper bound on the best achievable score from each DFS node and cut branches that can't beat the current worst kept result, and maintain the top-K results incrementally instead of collecting every placement before sorting and truncating at the end.