### PR TITLE
Clamp star count to [0,3] in word puzzle FoundWords

### DIFF
--- a/src/client/puzzles/friends/FoundWords.tsx
+++ b/src/client/puzzles/friends/FoundWords.tsx
@@ -28,7 +28,7 @@ export function FoundWords({
       ) : (
         <ul className="list-none m-0 p-0 overflow-y-auto">
           {[...found].reverse().map((w) => {
-            const starCount = Math.max(0, 3 - (maxLen - w.length));
+            const starCount = Math.min(3, Math.max(0, 3 - (maxLen - w.length)));
             return (
               <li
                 key={w}


### PR DESCRIPTION
Prevents a negative repeat count crash: on refresh, stale found words from a previous puzzle could briefly outlive the new puzzle's maxLen, pushing starCount above 3 and making the '⭒'.repeat(3 - starCount) call throw.