### PR TITLE
Reject placements that make a word's trace ambiguous

### DIFF
--- a/src/client/puzzles/friends/gen/best-first.ts
+++ b/src/client/puzzles/friends/gen/best-first.ts
@@ -1,0 +1,190 @@
+/**
+ * Best-first branch-and-bound search over a space of scored candidates.
+ *
+ * A {@link Candidate} is a node in a search tree: either fully resolved
+ * (carrying a finished result) or partial (able to expand into candidates
+ * that collectively cover its subtree). Every candidate advertises an
+ * admissible upper bound — `maxScore` — on anything reachable beneath it.
+ *
+ * {@link bestFirst} drives the search lazily from a max-heap keyed on that
+ * bound: pop the highest bound; if it is resolved, yield it (nothing still
+ * queued can beat it, because every bound is admissible); otherwise expand
+ * it and push the results. Pulling one value from the generator does only
+ * the work needed to prove that value is the best remaining, so the same
+ * search serves "give me the single best placement" and "keep going, I want
+ * ten" without a tuning constant like the old top-K results array.
+ *
+ * Correctness depends entirely on two properties the engine cannot infer,
+ * so it asserts them where it can:
+ *
+ * - **Admissibility**: no resolution under a candidate scores more than the
+ *   candidate's `maxScore`, and a resolved candidate's `maxScore` is its
+ *   actual score. Violations silently break the emission order, so the
+ *   engine at least rejects children whose bound exceeds their parent's.
+ * - **Progress**: expansion must strictly shrink the remaining space (e.g.
+ *   each child covers a longer prefix), or the loop never terminates. This
+ *   is unverifiable from outside; `maxExpansions` is the safety net.
+ *
+ * The trade-off against plain DFS is memory: the whole frontier lives in
+ * the heap, where DFS kept only the current path. The `targetScore` hook on
+ * {@link Candidate.expand} exists to claw that back — see its docs.
+ */
+
+export interface Candidate<R> {
+  /**
+   * Admissible upper bound: no resolution reachable from this candidate
+   * scores higher than this, and for a resolved candidate it equals the
+   * actual score. Read once, when the candidate enters the queue — later
+   * mutation has no effect on ordering.
+   */
+  readonly maxScore: number;
+
+  /** The finished result, or undefined while this candidate is partial. */
+  resolution(): R | undefined;
+
+  /**
+   * Produce candidates that collectively cover this candidate's search
+   * space. Only ever called on partial candidates, at most once each.
+   *
+   * `targetScore` is the highest bound still waiting in the queue
+   * (`-Infinity` when nothing is): until this candidate's best line drops
+   * below that, no queued rival can win, so implementations MAY descend
+   * depth-first internally while a branch's bound stays >= `targetScore`
+   * and return the deeper frontier instead of immediate children. That
+   * keeps the hot path out of the heap (bounding frontier memory and heap
+   * churn) but is purely an optimisation — returning direct children and
+   * ignoring `targetScore` is always correct.
+   *
+   * Two hard rules regardless: branches below `targetScore` must still be
+   * returned (unexpanded), never discarded — a later pull may need them —
+   * and every returned candidate's `maxScore` must be <= this one's.
+   */
+  expand(targetScore: number): Iterable<Candidate<R>>;
+}
+
+export interface BestFirstOptions {
+  /**
+   * Hard cap on the number of `expand()` calls, defaulting to unlimited.
+   * Once spent, remaining partials are dropped instead of expanded; already
+   * discovered resolutions still drain out in score order, matching the
+   * best-effort behaviour of the node budget in the old DFS. Results
+   * yielded after the budget runs out are no longer guaranteed optimal.
+   */
+  maxExpansions?: number;
+}
+
+interface Entry<R> {
+  candidate: Candidate<R>;
+  score: number;
+  seq: number;
+}
+
+/** `a` pops before `b`: higher score first, insertion order on ties. */
+function precedes<R>(a: Entry<R>, b: Entry<R>): boolean {
+  return a.score === b.score ? a.seq < b.seq : a.score > b.score;
+}
+
+class MaxHeap<R> {
+  private readonly entries: Entry<R>[] = [];
+
+  get size(): number {
+    return this.entries.length;
+  }
+
+  peekScore(): number {
+    return this.entries.length > 0
+      ? this.entries[0].score
+      : Number.NEGATIVE_INFINITY;
+  }
+
+  push(entry: Entry<R>): void {
+    const heap = this.entries;
+    heap.push(entry);
+    let i = heap.length - 1;
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      if (!precedes(heap[i], heap[parent])) {
+        break;
+      }
+      [heap[i], heap[parent]] = [heap[parent], heap[i]];
+      i = parent;
+    }
+  }
+
+  pop(): Entry<R> {
+    const heap = this.entries;
+    const top = heap[0];
+    const last = heap.pop();
+    if (heap.length > 0 && last !== undefined) {
+      heap[0] = last;
+      let i = 0;
+      for (;;) {
+        const left = 2 * i + 1;
+        const right = left + 1;
+        let best = i;
+        if (left < heap.length && precedes(heap[left], heap[best])) {
+          best = left;
+        }
+        if (right < heap.length && precedes(heap[right], heap[best])) {
+          best = right;
+        }
+        if (best === i) {
+          break;
+        }
+        [heap[i], heap[best]] = [heap[best], heap[i]];
+        i = best;
+      }
+    }
+    return top;
+  }
+}
+
+/**
+ * Lazily yield resolved results in non-increasing `maxScore` order.
+ *
+ * Nothing runs until the first pull, and each pull does only the expansion
+ * needed to surface the next-best resolution. Duplicate coverage is the
+ * domain's problem: if two expansions can reach the same resolution, it
+ * will be yielded twice.
+ */
+export function* bestFirst<R>(
+  seeds: Iterable<Candidate<R>>,
+  options: BestFirstOptions = {},
+): Generator<R, void, undefined> {
+  const { maxExpansions = Number.POSITIVE_INFINITY } = options;
+  const heap = new MaxHeap<R>();
+  let seq = 0;
+  const push = (candidate: Candidate<R>, parentBound: number): void => {
+    const score = candidate.maxScore;
+    if (Number.isNaN(score)) {
+      throw new TypeError('candidate maxScore must not be NaN');
+    }
+    if (score > parentBound) {
+      throw new RangeError(
+        `child maxScore ${score} exceeds parent bound ${parentBound}; ` +
+          'the bound is not admissible and emission order would be wrong',
+      );
+    }
+    heap.push({ candidate, score, seq: seq++ });
+  };
+  for (const seed of seeds) {
+    push(seed, Number.POSITIVE_INFINITY);
+  }
+  let expansions = 0;
+  while (heap.size > 0) {
+    const top = heap.pop();
+    const resolved = top.candidate.resolution();
+    if (resolved !== undefined) {
+      yield resolved;
+      continue;
+    }
+    if (expansions >= maxExpansions) {
+      continue;
+    }
+    expansions++;
+    const target = heap.peekScore();
+    for (const child of top.candidate.expand(target)) {
+      push(child, top.score);
+    }
+  }
+}

--- a/src/client/puzzles/friends/gen/is-unique-trace.ts
+++ b/src/client/puzzles/friends/gen/is-unique-trace.ts
@@ -1,0 +1,43 @@
+import { ekey, NEIGH } from '@/client/puzzles/friends/helpers';
+
+/**
+ * True if `word` has exactly one path through `grid`/`edges`. Null cells
+ * never match (they aren't a letter yet), so this only judges ambiguity
+ * among cells/edges that already exist at the time it's called.
+ */
+export function isUniqueTrace(
+  word: string,
+  grid: (string | null)[],
+  edges: Set<string>,
+): boolean {
+  let count = 0;
+  const dfs = (i: number, cell: number, used: Set<number>): void => {
+    if (count > 1) {
+      return;
+    }
+    if (i === word.length - 1) {
+      count++;
+      return;
+    }
+    for (const nb of NEIGH[cell]) {
+      if (used.has(nb) || grid[nb] !== word[i + 1]) {
+        continue;
+      }
+      if (!edges.has(ekey(cell.toString(), nb.toString()))) {
+        continue;
+      }
+      used.add(nb);
+      dfs(i + 1, nb, used);
+      used.delete(nb);
+      if (count > 1) {
+        return;
+      }
+    }
+  };
+  for (let s = 0; s < 16 && count <= 1; s++) {
+    if (grid[s] === word[0]) {
+      dfs(0, s, new Set([s]));
+    }
+  }
+  return count === 1;
+}

--- a/src/client/puzzles/friends/gen/search-placement.ts
+++ b/src/client/puzzles/friends/gen/search-placement.ts
@@ -5,6 +5,7 @@ import {
   NEIGH,
   shuffle,
 } from '@/client/puzzles/friends/helpers';
+import { isUniqueTrace } from '@/client/puzzles/friends/gen/is-unique-trace';
 
 export interface Placement {
   path: number[];
@@ -81,8 +82,20 @@ export function searchPlacement(
     }
     if (i === L) {
       if (fills > 0) {
-        const score = L * 30 + fills * 60 + reuse * 12 - newE * 2;
-        insertResult({ path: [...path], score, fills });
+        // Reject placements that would let the word be traced more than one
+        // way once committed — a word must be unambiguous to find.
+        const tempGrid = [...grid];
+        const tempEdges = new Set(edges);
+        for (let k = 0; k < path.length; k++) {
+          tempGrid[path[k]] = word[k];
+          if (k > 0) {
+            tempEdges.add(ekey(path[k - 1].toString(), path[k].toString()));
+          }
+        }
+        if (isUniqueTrace(word, tempGrid, tempEdges)) {
+          const score = L * 30 + fills * 60 + reuse * 12 - newE * 2;
+          insertResult({ path: [...path], score, fills });
+        }
       }
       return;
     }

--- a/src/client/puzzles/friends/gen/search-placement.ts
+++ b/src/client/puzzles/friends/gen/search-placement.ts
@@ -6,6 +6,10 @@ import {
   shuffle,
 } from '@/client/puzzles/friends/helpers';
 import { isUniqueTrace } from '@/client/puzzles/friends/gen/is-unique-trace';
+import {
+  bestFirst,
+  type Candidate,
+} from '@/client/puzzles/friends/gen/best-first';
 
 export interface Placement {
   path: number[];
@@ -16,8 +20,8 @@ export interface Placement {
 const MAX_PLACEMENTS = 3;
 
 /**
- * Upper bound on the score of any completion reachable from a DFS node that
- * has taken `i` of `L` steps with the given running totals.
+ * Upper bound on the score of any completion reachable from a search node
+ * that has taken `i` of `L` steps with the given running totals.
  *
  * The leaf score is `L*30 + fills*60 + reuse*12 - newE*2`, and `fills`,
  * `reuse`, `newE` only ever increase as the path extends. Each remaining
@@ -41,106 +45,145 @@ export function upperBoundScore(
   return L * 30 + fills * 60 + reuse * 12 - newE * 2 + 58 * (L - i);
 }
 
+/**
+ * A node in the placement search tree: a partial path of `word` through the
+ * grid. Immutable (each expansion produces new child instances) because
+ * best-first expansion order isn't depth-first — the old hand-rolled DFS
+ * relied on push/pop symmetry around a shared `degAdj` array, which only
+ * works under strict LIFO recursion.
+ */
+class PlacementCandidate implements Candidate<Placement> {
+  constructor(
+    private readonly word: string,
+    private readonly grid: (string | null)[],
+    private readonly edges: Set<string>,
+    private readonly i: number,
+    private readonly cell: number,
+    private readonly path: number[],
+    private readonly fills: number,
+    private readonly newE: number,
+    private readonly reuse: number,
+    private readonly degAdj: readonly number[],
+  ) {}
+
+  get maxScore(): number {
+    return upperBoundScore(
+      this.word.length,
+      this.i,
+      this.fills,
+      this.reuse,
+      this.newE,
+    );
+  }
+
+  resolution(): Placement | undefined {
+    if (this.i !== this.word.length || this.fills === 0) {
+      return undefined;
+    }
+    // Reject placements that would let the word be traced more than one way
+    // once committed — a word must be unambiguous to find.
+    const tempGrid = [...this.grid];
+    const tempEdges = new Set(this.edges);
+    for (let k = 0; k < this.path.length; k++) {
+      tempGrid[this.path[k]] = this.word[k];
+      if (k > 0) {
+        tempEdges.add(
+          ekey(this.path[k - 1].toString(), this.path[k].toString()),
+        );
+      }
+    }
+    if (!isUniqueTrace(this.word, tempGrid, tempEdges)) {
+      return undefined;
+    }
+    return { path: [...this.path], score: this.maxScore, fills: this.fills };
+  }
+
+  expand(): Iterable<Candidate<Placement>> {
+    if (this.i === this.word.length) {
+      // Terminal node with no valid resolution (ambiguous trace, or
+      // fills === 0) — dead end.
+      return [];
+    }
+    const children: Candidate<Placement>[] = [];
+    for (const nb of shuffle(NEIGH[this.cell])) {
+      if (this.path.includes(nb)) {
+        continue;
+      }
+      const g = this.grid[nb];
+      if (g !== null && g !== this.word[this.i]) {
+        continue;
+      }
+      const ek = ekey(this.cell.toString(), nb.toString());
+      const isNew = !this.edges.has(ek);
+      let degAdj = this.degAdj;
+      if (isNew) {
+        const degCell = cellDegree(this.cell, this.edges) + degAdj[this.cell];
+        const degNb = cellDegree(nb, this.edges) + degAdj[nb];
+        if (
+          degCell >= maxEdgesForCell(this.cell) ||
+          degNb >= maxEdgesForCell(nb)
+        ) {
+          continue;
+        }
+        degAdj = degAdj
+          .with(this.cell, degAdj[this.cell] + 1)
+          .with(nb, degAdj[nb] + 1);
+      }
+      children.push(
+        new PlacementCandidate(
+          this.word,
+          this.grid,
+          this.edges,
+          this.i + 1,
+          nb,
+          [...this.path, nb],
+          this.fills + (g === null ? 1 : 0),
+          this.newE + (isNew ? 1 : 0),
+          this.reuse + (g === null ? 0 : 1) + (isNew ? 0 : 1),
+          degAdj,
+        ),
+      );
+    }
+    return children;
+  }
+}
+
 export function searchPlacement(
   word: string,
   grid: (string | null)[],
   edges: Set<string>,
 ): Placement[] {
-  const results: Placement[] = [];
-  let nodes = 0;
-  const L = word.length;
-  const degAdj = Array.from<number>({ length: 16 }).fill(0);
-  const insertResult = (p: Placement): void => {
-    let idx = results.findIndex((r) => r.score < p.score);
-    if (idx === -1) {
-      idx = results.length;
-    }
-    if (idx < MAX_PLACEMENTS) {
-      results.splice(idx, 0, p);
-      if (results.length > MAX_PLACEMENTS) {
-        results.pop();
-      }
-    }
-  };
-  const dfs = (
-    i: number,
-    cell: number,
-    path: number[],
-    fills: number,
-    newE: number,
-    reuse: number,
-  ): void => {
-    if (nodes++ > 6000) {
-      return;
-    }
-    if (
-      results.length === MAX_PLACEMENTS &&
-      upperBoundScore(L, i, fills, reuse, newE) <=
-        results[MAX_PLACEMENTS - 1].score
-    ) {
-      return;
-    }
-    if (i === L) {
-      if (fills > 0) {
-        // Reject placements that would let the word be traced more than one
-        // way once committed — a word must be unambiguous to find.
-        const tempGrid = [...grid];
-        const tempEdges = new Set(edges);
-        for (let k = 0; k < path.length; k++) {
-          tempGrid[path[k]] = word[k];
-          if (k > 0) {
-            tempEdges.add(ekey(path[k - 1].toString(), path[k].toString()));
-          }
-        }
-        if (isUniqueTrace(word, tempGrid, tempEdges)) {
-          const score = L * 30 + fills * 60 + reuse * 12 - newE * 2;
-          insertResult({ path: [...path], score, fills });
-        }
-      }
-      return;
-    }
-    for (const nb of shuffle(NEIGH[cell])) {
-      if (path.includes(nb)) {
-        continue;
-      }
-      const g = grid[nb];
-      if (g !== null && g !== word[i]) {
-        continue;
-      }
-      const ek = ekey(cell.toString(), nb.toString());
-      const isNew = !edges.has(ek);
-      if (isNew) {
-        if (
-          cellDegree(cell, edges) + degAdj[cell] >= maxEdgesForCell(cell) ||
-          cellDegree(nb, edges) + degAdj[nb] >= maxEdgesForCell(nb)
-        ) {
-          continue;
-        }
-        degAdj[cell]++;
-        degAdj[nb]++;
-      }
-      path.push(nb);
-      dfs(
-        i + 1,
-        nb,
-        path,
-        fills + (g === null ? 1 : 0),
-        newE + (isNew ? 1 : 0),
-        reuse + (g === null ? 0 : 1) + (isNew ? 0 : 1),
-      );
-      path.pop();
-      if (isNew) {
-        degAdj[cell]--;
-        degAdj[nb]--;
-      }
-    }
-  };
+  const zeroDegAdj = Array.from<number>({ length: 16 }).fill(0);
+  const seeds: Candidate<Placement>[] = [];
   for (let s = 0; s < 16; s++) {
     const g = grid[s];
     if (g !== null && g !== word[0]) {
       continue;
     }
-    dfs(1, s, [s], g === null ? 1 : 0, 0, g === null ? 0 : 1);
+    seeds.push(
+      new PlacementCandidate(
+        word,
+        grid,
+        edges,
+        1,
+        s,
+        [s],
+        g === null ? 1 : 0,
+        0,
+        g === null ? 0 : 1,
+        zeroDegAdj,
+      ),
+    );
+  }
+  const results: Placement[] = [];
+  // maxExpansions counts expand() calls, not total node visits like the old
+  // `nodes` counter, so this is an approximate carryover of the old budget
+  // rather than an exact equivalent.
+  for (const placement of bestFirst(seeds, { maxExpansions: 6000 })) {
+    results.push(placement);
+    if (results.length >= MAX_PLACEMENTS) {
+      break;
+    }
   }
   return results;
 }

--- a/src/client/puzzles/friends/gen/try-build.ts
+++ b/src/client/puzzles/friends/gen/try-build.ts
@@ -15,12 +15,13 @@ import {
   SECONDARY_SEEDS,
   shareRoot,
 } from '@/client/puzzles/friends/words';
-import {
-  type Placement,
-  searchPlacement,
-} from '@/client/puzzles/friends/gen/search-placement';
+import { searchPlacement } from '@/client/puzzles/friends/gen/search-placement';
 import { scanAvoid } from '@/client/puzzles/friends/gen/scan-avoid';
 import { enrich } from '@/client/puzzles/friends/gen/enrich';
+import {
+  bestFirst,
+  type Candidate,
+} from '@/client/puzzles/friends/gen/best-first';
 
 export interface BuildResult {
   grid: string[];
@@ -30,10 +31,12 @@ export interface BuildResult {
   seed2: string;
 }
 
-interface DfsState {
+interface FillState {
   grid: (string | null)[];
   edges: Set<string>;
   maxWordLen: number;
+  wordsPlaced: number;
+  usedWords: Set<string>;
 }
 
 export function countPotentialFit(
@@ -109,110 +112,106 @@ export async function tryBuild(seed: string): Promise<BuildResult | null> {
   }
   const sortedLens = allLens.filter((l) => wordsByLen.has(l));
 
-  let bestResult: BuildResult | null = null;
-  let bestScore = -Infinity;
-  // Exclude both seeds from fill DFS so they can't be re-placed.
-  const usedWords = new Set<string>([seed, seed2Word]);
+  const initialMaxWordLen = sortedLens[0] ?? 9;
+  const seedCandidate = new FillCandidate(
+    {
+      grid: initialGrid,
+      edges: initialEdges,
+      maxWordLen: initialMaxWordLen,
+      wordsPlaced: 0,
+      // Exclude both seeds from the fill search so they can't be re-placed.
+      usedWords: new Set<string>([seed, seed2Word]),
+    },
+    wordsByLen,
+    sortedLens,
+  );
 
-  const dfs = async (state: DfsState, wordsPlaced: number): Promise<void> => {
+  // bestFirst yields fully-filled grids in strictly descending maxScore
+  // order, and a full grid's real value can never exceed its own bound — so
+  // the first one that verifies is provably the best reachable result. No
+  // need to keep searching for a higher-scoring accepted grid.
+  for (const filled of bestFirst([seedCandidate])) {
+    const filledGrid = filled.grid as string[];
+    // Copy edges: enrich mutates them; filled.edges may be frozen by immer.
+    const edges = new Set(filled.edges);
+    if (scanAvoid(filledGrid, edges).size > 0) {
+      continue;
+    }
+    const ctx = await boardContext(filledGrid);
+    enrich(filledGrid, edges, ctx);
+    const accepted = scanWords(filledGrid, edges, ctx);
+    if (!accepted.has(seed) || !accepted.has(seed2Word)) {
+      continue;
+    }
+    return { grid: filledGrid, edges, accepted, seed, seed2: seed2Word };
+  }
+  return null;
+}
+
+/**
+ * A node in the fill search tree: a grid partially filled with words, plus
+ * the bookkeeping (`maxWordLen`, `usedWords`) needed to expand it further.
+ * Immutable — best-first expansion order isn't depth-first, so state the old
+ * DFS mutated in place around the recursive call (`usedWords`, added before
+ * recursing and deleted after) must instead be carried per-candidate.
+ */
+class FillCandidate implements Candidate<FillState> {
+  constructor(
+    private readonly state: FillState,
+    private readonly wordsByLen: Map<number, string[]>,
+    private readonly sortedLens: readonly number[],
+  ) {}
+
+  get maxScore(): number {
+    const { grid, maxWordLen, usedWords, wordsPlaced } = this.state;
     const remaining = FILLWORDS.filter(
-      (w) => !usedWords.has(w) && w.length <= state.maxWordLen,
+      (w) => !usedWords.has(w) && w.length <= maxWordLen,
     );
-    const emptyCount = state.grid.filter((c) => c === null).length;
+    // Valid for both pruning and leaf scoring: placing a word increments
+    // wordsPlaced by 1 but removes the word from remaining and tightens the
+    // empty-slot budget, so the bound is non-increasing along any path.
+    return wordsPlaced + countPotentialFit(grid, remaining);
+  }
 
-    // upperBound is valid for both pruning and leaf scoring: placing a word
-    // increments wordsPlaced by 1 but removes the word from remaining and
-    // tightens empty-slot budget, so the bound is non-increasing along any path.
-    const upperBound = wordsPlaced + countPotentialFit(state.grid, remaining);
-    if (upperBound <= bestScore) {
-      return;
-    }
+  resolution(): FillState | undefined {
+    return this.state.grid.includes(null) ? undefined : this.state;
+  }
 
-    if (emptyCount === 0) {
-      const filledGrid = state.grid as string[];
-      // Copy edges: enrich mutates them; state.edges may be frozen by immer.
-      const edges = new Set(state.edges);
-      if (scanAvoid(filledGrid, edges).size > 0) {
-        return;
-      }
-      const ctx = await boardContext(filledGrid);
-      enrich(filledGrid, edges, ctx);
-      const accepted = scanWords(filledGrid, edges, ctx);
-      if (!accepted.has(seed) || !accepted.has(seed2Word)) {
-        return;
-      }
-      if (upperBound > bestScore) {
-        bestScore = upperBound;
-        bestResult = {
-          grid: filledGrid,
-          edges,
-          accepted,
-          seed,
-          seed2: seed2Word,
-        };
-      }
-      return;
-    }
-
+  expand(): Iterable<Candidate<FillState>> {
+    const { grid, edges, maxWordLen, usedWords } = this.state;
     let targetLen: number | null = null;
-    const candidates: {
-      word: string;
-      placement: Placement;
-      candidateScore: number;
-    }[] = [];
+    const children: Candidate<FillState>[] = [];
 
-    for (const len of sortedLens) {
-      if (len > state.maxWordLen) {
+    for (const len of this.sortedLens) {
+      if (len > maxWordLen) {
         continue;
       }
-      const wordsOfLen = wordsByLen.get(len) ?? [];
+      const wordsOfLen = this.wordsByLen.get(len) ?? [];
       for (const word of wordsOfLen) {
         if (usedWords.has(word)) {
           continue;
         }
-        const placements = searchPlacement(word, state.grid, state.edges);
+        const placements = searchPlacement(word, grid, edges);
         if (placements.length === 0) {
           continue;
         }
         targetLen = len;
         for (const placement of placements) {
-          // Temp copy for scoring; produce would be wasteful here.
-          const tempGrid = [...state.grid];
-          const tempEdges = new Set(state.edges);
-          applyWord(word, placement.path, tempGrid, tempEdges);
-          const nextRemaining = remaining.filter((w) => w !== word);
-          const candidateScore =
-            wordsPlaced + 1 + countPotentialFit(tempGrid, nextRemaining);
-          candidates.push({ word, placement, candidateScore });
+          const nextState = produce(this.state, (draft) => {
+            applyWord(word, placement.path, draft.grid, draft.edges);
+            draft.maxWordLen = len;
+            draft.wordsPlaced += 1;
+            draft.usedWords.add(word);
+          });
+          children.push(
+            new FillCandidate(nextState, this.wordsByLen, this.sortedLens),
+          );
         }
       }
       if (targetLen !== null) {
         break;
       }
     }
-
-    if (candidates.length === 0 || targetLen === null) {
-      return;
-    }
-    candidates.sort((a, b) => b.candidateScore - a.candidateScore);
-    const capturedLen = targetLen;
-    const MAX_BRANCH = 15;
-
-    for (const { word, placement } of candidates.slice(0, MAX_BRANCH)) {
-      usedWords.add(word);
-      const nextState = produce(state, (draft) => {
-        applyWord(word, placement.path, draft.grid, draft.edges);
-        draft.maxWordLen = capturedLen;
-      });
-      await dfs(nextState, wordsPlaced + 1);
-      usedWords.delete(word);
-    }
-  };
-
-  const initialMaxWordLen = sortedLens[0] ?? 9;
-  await dfs(
-    { grid: initialGrid, edges: initialEdges, maxWordLen: initialMaxWordLen },
-    0,
-  );
-  return bestResult;
+    return children;
+  }
 }

--- a/test/client/puzzles/friends/gen/best-first.test.ts
+++ b/test/client/puzzles/friends/gen/best-first.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import {
+  bestFirst,
+  type Candidate,
+} from '@/client/puzzles/friends/gen/best-first';
+
+/** A resolved result carrying its own score so tests can check ordering. */
+interface Item {
+  name: string;
+  score: number;
+}
+
+function leaf(name: string, score: number): Candidate<Item> {
+  return {
+    maxScore: score,
+    resolution: () => ({ name, score }),
+    expand: () => {
+      throw new Error(`expand() called on resolved candidate ${name}`);
+    },
+  };
+}
+
+/** A partial candidate with an explicit expand implementation. */
+function partial(
+  maxScore: number,
+  expand: (targetScore: number) => Candidate<Item>[],
+): Candidate<Item> {
+  return {
+    maxScore,
+    // eslint-disable-next-line unicorn/no-useless-undefined -- the Candidate contract needs an explicit `Item | undefined`, which an empty body cannot satisfy
+    resolution: () => undefined,
+    expand,
+  };
+}
+
+/** A partial candidate whose children are produced on demand. */
+function node(
+  maxScore: number,
+  children: () => Candidate<Item>[],
+): Candidate<Item> {
+  return partial(maxScore, children);
+}
+
+function drain(generator: Generator<Item>): Item[] {
+  return [...generator];
+}
+
+function names(items: Item[]): string[] {
+  return items.map((item) => item.name);
+}
+
+describe('bestFirst', () => {
+  it('yields nothing for empty seeds', () => {
+    expect(drain(bestFirst<Item>([]))).toHaveLength(0);
+  });
+
+  it('yields a single resolved seed', () => {
+    expect(names(drain(bestFirst([leaf('a', 5)])))).toEqual(['a']);
+  });
+
+  it('yields resolved seeds in descending score order', () => {
+    const results = drain(
+      bestFirst([leaf('low', 1), leaf('high', 9), leaf('mid', 5)]),
+    );
+    expect(names(results)).toEqual(['high', 'mid', 'low']);
+  });
+
+  it('breaks score ties by insertion order', () => {
+    const results = drain(
+      bestFirst([leaf('first', 5), leaf('second', 5), leaf('third', 5)]),
+    );
+    expect(names(results)).toEqual(['first', 'second', 'third']);
+  });
+
+  it('expands partials and interleaves their resolutions globally by score', () => {
+    // The partial's bound (100) beats the resolved leaf (60), so it must be
+    // expanded before 'outside' can safely be yielded; its actual best is
+    // only 40, so 'outside' still comes out first.
+    const partial = node(100, () => [leaf('inner-a', 40), leaf('inner-b', 20)]);
+    const results = drain(bestFirst([leaf('outside', 60), partial]));
+    expect(names(results)).toEqual(['outside', 'inner-a', 'inner-b']);
+  });
+
+  it('handles multi-level trees, yielding all leaves in score order', () => {
+    const tree = node(100, () => [
+      node(90, () => [leaf('a', 85), leaf('b', 15)]),
+      node(50, () => [node(45, () => [leaf('c', 45)]), leaf('d', 30)]),
+      leaf('e', 70),
+    ]);
+    expect(names(drain(bestFirst([tree])))).toEqual(['a', 'e', 'c', 'd', 'b']);
+  });
+
+  it('skips dead ends (partials that expand to nothing)', () => {
+    const deadEnd = node(100, () => []);
+    const results = drain(bestFirst([deadEnd, leaf('survivor', 10)]));
+    expect(names(results)).toEqual(['survivor']);
+  });
+
+  it('does no work until the generator is first pulled', () => {
+    const expand = jest.fn(() => [leaf('child', 10)]);
+    const generator = bestFirst([partial(50, expand)]);
+    expect(expand).not.toHaveBeenCalled();
+    generator.next();
+    expect(expand).toHaveBeenCalledTimes(1);
+  });
+
+  it('never expands a partial that cannot beat the requested results', () => {
+    // With bound 40, this partial can never beat the 60-point leaf, so
+    // pulling one result must not touch it.
+    const expand = jest.fn(() => [leaf('unreachable', 40)]);
+    const generator = bestFirst([leaf('best', 60), partial(40, expand)]);
+    expect(generator.next().value?.name).toBe('best');
+    expect(expand).not.toHaveBeenCalled();
+  });
+
+  it('supports pulling arbitrarily many results, not a fixed top-K', () => {
+    const seeds = Array.from({ length: 20 }, (_, i) =>
+      node(100 - i, () => [leaf(`leaf-${i}`, 100 - i)]),
+    );
+    const results = drain(bestFirst(seeds));
+    expect(results).toHaveLength(20);
+    const scores = results.map((r) => r.score);
+    expect(scores).toEqual([...scores].sort((a, b) => b - a));
+  });
+
+  describe('targetScore', () => {
+    it('passes the best queued bound as the expansion target', () => {
+      const seen: number[] = [];
+      const watcher = partial(100, (target) => {
+        seen.push(target);
+        return [];
+      });
+      drain(bestFirst([watcher, leaf('rival', 70)]));
+      expect(seen).toEqual([70]);
+    });
+
+    it('passes -Infinity when nothing else is queued', () => {
+      const seen: number[] = [];
+      const watcher = partial(100, (target) => {
+        seen.push(target);
+        return [];
+      });
+      drain(bestFirst([watcher]));
+      expect(seen).toEqual([Number.NEGATIVE_INFINITY]);
+    });
+
+    it('accepts internally-descended expansions (deep frontier, not direct children)', () => {
+      // A candidate exploiting targetScore returns grandchildren directly.
+      // The engine must order them correctly regardless of tree depth.
+      const descending = node(100, () => [
+        leaf('deep-best', 95),
+        node(60, () => [leaf('deep-rest', 55)]),
+      ]);
+      const results = drain(bestFirst([descending, leaf('rival', 70)]));
+      expect(names(results)).toEqual(['deep-best', 'rival', 'deep-rest']);
+    });
+  });
+
+  describe('contract enforcement', () => {
+    it('rejects NaN maxScore on a seed', () => {
+      expect(() => drain(bestFirst([leaf('bad', Number.NaN)]))).toThrow(
+        TypeError,
+      );
+    });
+
+    it('rejects NaN maxScore on a child', () => {
+      const parent = node(10, () => [leaf('bad', Number.NaN)]);
+      expect(() => drain(bestFirst([parent]))).toThrow(TypeError);
+    });
+
+    it('rejects a child whose bound exceeds its parent (inadmissible bound)', () => {
+      const parent = node(10, () => [leaf('cheat', 11)]);
+      expect(() => drain(bestFirst([parent]))).toThrow(RangeError);
+    });
+
+    it('accepts a child whose bound equals its parent', () => {
+      const parent = node(10, () => [leaf('exact', 10)]);
+      expect(names(drain(bestFirst([parent])))).toEqual(['exact']);
+    });
+  });
+
+  describe('maxExpansions budget', () => {
+    it('stops expanding once spent but still drains discovered resolutions in order', () => {
+      // Budget of one: the root expands, revealing a leaf and a partial.
+      // The partial (bound 90) pops first but is dropped; the leaf still
+      // comes out.
+      const starved = jest.fn(() => [leaf('never', 90)]);
+      const root = node(100, () => [partial(90, starved), leaf('found', 10)]);
+      const results = drain(bestFirst([root], { maxExpansions: 1 }));
+      expect(names(results)).toEqual(['found']);
+      expect(starved).not.toHaveBeenCalled();
+    });
+
+    it('yields nothing from partial seeds with a budget of zero', () => {
+      const root = node(100, () => [leaf('unreached', 10)]);
+      expect(drain(bestFirst([root], { maxExpansions: 0 }))).toHaveLength(0);
+    });
+
+    it('still yields resolved seeds with a budget of zero', () => {
+      const results = drain(
+        bestFirst([leaf('a', 5), node(100, () => [])], { maxExpansions: 0 }),
+      );
+      expect(names(results)).toEqual(['a']);
+    });
+  });
+
+  it('reads maxScore once, at queue insertion', () => {
+    // Seeds are queued on the first pull; mutating maxScore after that must
+    // not affect ordering. The mutable candidate was queued at 80 and stays
+    // there even though it claims 10 by the time it pops.
+    const mutable = {
+      maxScore: 80,
+      resolution: (): Item | undefined => ({ name: 'mutable', score: 80 }),
+      expand: (): Candidate<Item>[] => [],
+    };
+    const generator = bestFirst([leaf('best', 100), mutable, leaf('mid', 50)]);
+    expect(generator.next().value?.name).toBe('best');
+    mutable.maxScore = 10;
+    expect(names([...generator])).toEqual(['mutable', 'mid']);
+  });
+
+  describe('randomised trees match brute-force enumeration', () => {
+    /** Deterministic LCG so failures are reproducible. */
+    function makeRandom(seed: number): () => number {
+      let state = seed >>> 0;
+      return () => {
+        state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+        return state / 2 ** 32;
+      };
+    }
+
+    interface TreeNode {
+      bound: number;
+      leafScore?: number;
+      children: TreeNode[];
+    }
+
+    function buildTree(
+      random: () => number,
+      bound: number,
+      depth: number,
+      root = false,
+    ): TreeNode {
+      // The root always branches (with at least two children) so every
+      // generated tree exercises real ordering, not a single leaf.
+      if (!root && (depth === 0 || random() < 0.3)) {
+        // Resolved leaves score exactly their bound, per the contract.
+        return { bound, leafScore: bound, children: [] };
+      }
+      const width = (root ? 2 : 1) + Math.floor(random() * 3);
+      const children = Array.from({ length: width }, () =>
+        buildTree(
+          random,
+          Math.floor(bound * (0.5 + random() * 0.5)),
+          depth - 1,
+        ),
+      );
+      return { bound, children };
+    }
+
+    function collectLeafScores(tree: TreeNode): number[] {
+      if (tree.leafScore !== undefined) {
+        return [tree.leafScore];
+      }
+      return tree.children.flatMap((child) => collectLeafScores(child));
+    }
+
+    /** Naive candidate: ignores targetScore, returns direct children. */
+    function naive(tree: TreeNode): Candidate<Item> {
+      if (tree.leafScore !== undefined) {
+        return leaf(`leaf@${tree.leafScore}`, tree.leafScore);
+      }
+      return node(tree.bound, () => tree.children.map((child) => naive(child)));
+    }
+
+    /**
+     * Descending candidate: honours targetScore by inlining any child
+     * subtree whose bound stays at or above the target, returning a deeper
+     * frontier — the optimisation real domains are expected to use.
+     */
+    function descending(tree: TreeNode): Candidate<Item> {
+      if (tree.leafScore !== undefined) {
+        return leaf(`leaf@${tree.leafScore}`, tree.leafScore);
+      }
+      const frontier = (
+        subtree: TreeNode,
+        target: number,
+      ): Candidate<Item>[] =>
+        subtree.leafScore === undefined && subtree.bound >= target
+          ? subtree.children.flatMap((child) => frontier(child, target))
+          : [descending(subtree)];
+      return partial(tree.bound, (target) =>
+        tree.children.flatMap((child) => frontier(child, target)),
+      );
+    }
+
+    it.each([1, 2, 3, 4, 5])(
+      'seed %i: both naive and descending traversals yield every leaf in sorted order',
+      (seed) => {
+        const random = makeRandom(seed * 999_331);
+        const tree = buildTree(random, 1000, 6, true);
+        const expected = collectLeafScores(tree).sort((a, b) => b - a);
+        expect(expected.length).toBeGreaterThan(1);
+
+        const naiveScores = drain(bestFirst([naive(tree)])).map(
+          (item) => item.score,
+        );
+        const descendingScores = drain(bestFirst([descending(tree)])).map(
+          (item) => item.score,
+        );
+
+        expect(naiveScores).toEqual(expected);
+        expect(descendingScores).toEqual(expected);
+      },
+    );
+  });
+});

--- a/test/client/puzzles/friends/gen/is-unique-trace.test.ts
+++ b/test/client/puzzles/friends/gen/is-unique-trace.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { isUniqueTrace } from '@/client/puzzles/friends/gen/is-unique-trace';
+
+describe('isUniqueTrace', () => {
+  it('returns true when exactly one path traces the word', () => {
+    const grid: (string | null)[] = [
+      'c',
+      'a',
+      't',
+      's',
+      ...Array.from<null>({ length: 12 }).fill(null),
+    ];
+    const edges = new Set(['0-1', '1-2', '2-3']);
+    expect(isUniqueTrace('cats', grid, edges)).toBe(true);
+  });
+
+  it('returns false when two independent paths trace the same word', () => {
+    // Path 1: 0(c) → 1(a) → 2(t) → 3(s)
+    // Path 2: 4(c) → 5(a) → 2(t) → 3(s)   (cell 5 is diagonally adjacent to 2)
+    const grid: (string | null)[] = [
+      'c',
+      'a',
+      't',
+      's',
+      'c',
+      'a',
+      ...Array.from<null>({ length: 10 }).fill(null),
+    ];
+    const edges = new Set(['0-1', '1-2', '2-3', '4-5', '2-5']);
+    expect(isUniqueTrace('cats', grid, edges)).toBe(false);
+  });
+
+  it('returns false when the word cannot be traced at all', () => {
+    const grid: (string | null)[] = Array.from<null>({ length: 16 }).fill(null);
+    const edges = new Set<string>();
+    expect(isUniqueTrace('cats', grid, edges)).toBe(false);
+  });
+
+  it('ignores a second candidate path broken by a missing edge', () => {
+    // Cell 5 also spells 'ca' via 4-5, but there's no edge from 5 onward, so
+    // only the 0-1-2-3 path can actually complete the word.
+    const grid: (string | null)[] = [
+      'c',
+      'a',
+      't',
+      's',
+      'c',
+      'a',
+      ...Array.from<null>({ length: 10 }).fill(null),
+    ];
+    const edges = new Set(['0-1', '1-2', '2-3', '4-5']);
+    expect(isUniqueTrace('cats', grid, edges)).toBe(true);
+  });
+});

--- a/test/client/puzzles/friends/gen/search-placement.test.ts
+++ b/test/client/puzzles/friends/gen/search-placement.test.ts
@@ -128,6 +128,20 @@ describe('searchPlacement', () => {
     }
   });
 
+  it('rejects every candidate when the word is already traceable elsewhere on the board', () => {
+    // 'cat' is already fully spelled via 12(c)-13(a)-14(t), all existing
+    // edges. That trace is never disturbed by a new placement, so any
+    // fill-based completion elsewhere on the board would leave the word
+    // traceable two ways — every candidate must therefore be rejected.
+    const grid = emptyGrid();
+    grid[12] = 'c';
+    grid[13] = 'a';
+    grid[14] = 't';
+    const edges = new Set([ekey('12', '13'), ekey('13', '14')]);
+    const results = searchPlacement('cat', grid, edges);
+    expect(results).toHaveLength(0);
+  });
+
   describe('upperBoundScore', () => {
     it('equals the exact leaf formula when i === L', () => {
       const L = 4;

--- a/test/client/puzzles/friends/gen/try-build.test.ts
+++ b/test/client/puzzles/friends/gen/try-build.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import { produce } from 'immer';
 
 // Importing try-build triggers enableMapSet(), which is required for Immer to
-// handle the Set<string> edges field in DfsState. This import must be present
+// handle the Set<string> edges field in FillState. This import must be present
 // for the test below to pass, and removing enableMapSet() from try-build will
 // break it.
 import { countPotentialFit } from '@/client/puzzles/friends/gen/try-build';


### PR DESCRIPTION
searchPlacement now discards any candidate path whose commitment would let
the word be traced more than one way on the resulting board, even if that
candidate scores highest. Applies only at placement time -- enrich.ts is
untouched and may still add edges that create ambiguity for already-placed
words.