### PR TITLE
Add "text cutout" QR module style

### DIFF
--- a/src/client/qr/QRCode.tsx
+++ b/src/client/qr/QRCode.tsx
@@ -11,7 +11,7 @@ import { QRDebugPanel } from '@/client/qr/QRDebugPanel';
 export interface QRCodeContent {
   text: string;
   shouldOptimiseUrl: boolean;
-  dotStyle: 'square' | 'dot' | 'text';
+  dotStyle: 'square' | 'dot' | 'text' | 'cutout';
   dotRadius: number;
   rasterText: string;
   rasterFont: string;

--- a/src/client/qr/QRCode.tsx
+++ b/src/client/qr/QRCode.tsx
@@ -6,6 +6,7 @@ import {
   useQRCode,
   type ErrorCorrectionLevel,
 } from '@/client/qr/thirdparty/qrcode.react';
+import { useCutoutLayout } from '@/client/qr/thirdparty/qrcode.react/textCutout';
 import { QRDebugPanel } from '@/client/qr/QRDebugPanel';
 
 export interface QRCodeContent {
@@ -111,7 +112,16 @@ export function QRCode({
   ref: RefObject<HTMLDivElement | null>;
 }>): JSX.Element {
   const { actualValue, qrDetails, debugMessage } = useOptimisedQr(content);
-  const qrDebugDetails = useDebugDetails(qrDetails);
+  // The cutout style re-encodes independently (always High error correction,
+  // whatever version that needs) — when it's active, the debug panel should
+  // describe that actual encoding, not the plain one computed above, or it
+  // would show a version/level nothing on screen actually uses.
+  const cutoutLayout = useCutoutLayout(
+    qrDetails,
+    content.dotStyle === 'cutout' ? content.rasterText : '',
+    content.rasterFont,
+  );
+  const qrDebugDetails = useDebugDetails(cutoutLayout ?? qrDetails);
 
   return (
     <>

--- a/src/client/qr/QRCodeForm.tsx
+++ b/src/client/qr/QRCodeForm.tsx
@@ -290,10 +290,18 @@ export function QRCodeForm(): JSX.Element {
           qrContent={qrContent}
           updateQRCode={setQRContent}
         />
-        <label className="w-full flex flex-row items-center gap-2">
+        <label
+          className="w-full flex flex-row items-center gap-2"
+          title={
+            qrContent.dotStyle === 'cutout'
+              ? 'Text cutout always uses High error correction'
+              : undefined
+          }
+        >
           Min error correction
           <select
             value={qrContent.minErrorCorrectionLevel}
+            disabled={qrContent.dotStyle === 'cutout'}
             onChange={(event) => {
               startTransition(() => {
                 setQRContent((draft) => {

--- a/src/client/qr/QRCodeForm.tsx
+++ b/src/client/qr/QRCodeForm.tsx
@@ -51,8 +51,8 @@ function buildSearchParams(qrState: QRCodeContent): URLSearchParams {
     if (qrState.dotRadius !== DEFAULTS.dotRadius) {
       params.set('dotRadius', Math.round(qrState.dotRadius * 200).toString());
     }
-  } else if (qrState.dotStyle === 'text') {
-    params.set('dotStyle', 'text');
+  } else if (qrState.dotStyle === 'text' || qrState.dotStyle === 'cutout') {
+    params.set('dotStyle', qrState.dotStyle);
     if (qrState.rasterText) {
       params.set('rasterText', qrState.rasterText);
     }
@@ -74,12 +74,14 @@ function extractContent(searchParams: URLSearchParams): QRCodeContent {
     : paramText;
 
   const dotStyleParam = searchParams.get('dotStyle');
-  const dotStyle: 'square' | 'dot' | 'text' =
+  const dotStyle: 'square' | 'dot' | 'text' | 'cutout' =
     dotStyleParam === 'dot'
       ? 'dot'
       : dotStyleParam === 'text'
         ? 'text'
-        : DEFAULTS.dotStyle;
+        : dotStyleParam === 'cutout'
+          ? 'cutout'
+          : DEFAULTS.dotStyle;
   const rawRadius = searchParams.get('dotRadius');
   const dotRadius =
     rawRadius !== null && !Number.isNaN(Number(rawRadius))
@@ -240,7 +242,8 @@ export function QRCodeForm(): JSX.Element {
                   draft.dotStyle = event.target.value as
                     | 'square'
                     | 'dot'
-                    | 'text';
+                    | 'text'
+                    | 'cutout';
                 });
               });
             }}
@@ -248,6 +251,7 @@ export function QRCodeForm(): JSX.Element {
             <option value="square">Square</option>
             <option value="dot">Dot</option>
             <option value="text">Text raster</option>
+            <option value="cutout">Text cutout</option>
           </select>
         </label>
         <label

--- a/src/client/qr/QRTextStyleControls.tsx
+++ b/src/client/qr/QRTextStyleControls.tsx
@@ -19,7 +19,9 @@ export default function QRTextStyleControls({
       <label
         className={
           'w-full flex flex-row items-center gap-2 overflow-hidden transition-discrete transition-[height] duration-300 ease' +
-          (qrContent.dotStyle === 'text' ? ' h-lh' : ' h-0')
+          (qrContent.dotStyle === 'text' || qrContent.dotStyle === 'cutout'
+            ? ' h-lh'
+            : ' h-0')
         }
       >
         Raster text
@@ -45,7 +47,9 @@ export default function QRTextStyleControls({
       <label
         className={
           'w-full flex flex-row items-center gap-2 overflow-hidden transition-discrete transition-[height] duration-300 ease' +
-          (qrContent.dotStyle === 'text' ? ' h-lh' : ' h-0')
+          (qrContent.dotStyle === 'text' || qrContent.dotStyle === 'cutout'
+            ? ' h-lh'
+            : ' h-0')
         }
       >
         Font

--- a/src/client/qr/thirdparty/qrcode.react/constants.ts
+++ b/src/client/qr/thirdparty/qrcode.react/constants.ts
@@ -1,0 +1,9 @@
+// Shared layout constants for the 'text' and 'cutout' dot styles.
+
+// The quiet-zone width, in modules, drawn around every rendered QR code.
+export const SPEC_MARGIN_SIZE = 4;
+
+// Structural zones: top 9 rows (TL+TR finders + format info) and bottom 8 rows
+// (BL finder + format info). Interior data rows: 9 … size−9 = size−17 rows total.
+export const STRUCTURAL_TOP_ROWS = 9;
+export const STRUCTURAL_BOTTOM_ROWS = 8;

--- a/src/client/qr/thirdparty/qrcode.react/fontFit.ts
+++ b/src/client/qr/thirdparty/qrcode.react/fontFit.ts
@@ -1,0 +1,31 @@
+/**
+ * Binary-searches the largest font size (in px) at which `text`, rendered in
+ * `font`, has ink bounds no larger than maxWidth × maxHeight.
+ *
+ * Searches by actual ink bounds rather than the nominal em size, so text
+ * without descenders (e.g. "QR") can use a larger font. Falls back to the
+ * candidate font size itself when actual bounding boxes aren't available
+ * (e.g. under jsdom in tests).
+ */
+export function fitFontSize(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  font: string,
+  maxWidth: number,
+  maxHeight: number,
+): number {
+  let lo = 1,
+    hi = Math.max(maxWidth, maxHeight) * 2;
+  while (lo < hi - 1) {
+    const mid = (lo + hi) >> 1;
+    ctx.font = `bold ${mid}px "${font}"`;
+    const m = ctx.measureText(text);
+    const inkH = m.actualBoundingBoxAscent + m.actualBoundingBoxDescent;
+    if (m.width <= maxWidth && (inkH > 0 ? inkH : mid) <= maxHeight) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}

--- a/src/client/qr/thirdparty/qrcode.react/fontFit.ts
+++ b/src/client/qr/thirdparty/qrcode.react/fontFit.ts
@@ -6,6 +6,11 @@
  * without descenders (e.g. "QR") can use a larger font. Falls back to the
  * candidate font size itself when actual bounding boxes aren't available
  * (e.g. under jsdom in tests).
+ *
+ * `bold` defaults to true for the decorative raster overlay's look; the
+ * cutout style passes false, since an already-heavy display font (e.g.
+ * Impact) synthetically bolded on top gets thick enough to blob adjacent
+ * strokes together once its silhouette is also dilated for the clear border.
  */
 export function fitFontSize(
   ctx: CanvasRenderingContext2D,
@@ -13,12 +18,14 @@ export function fitFontSize(
   font: string,
   maxWidth: number,
   maxHeight: number,
+  bold = true,
 ): number {
+  const weight = bold ? 'bold ' : '';
   let lo = 1,
     hi = Math.max(maxWidth, maxHeight) * 2;
   while (lo < hi - 1) {
     const mid = (lo + hi) >> 1;
-    ctx.font = `bold ${mid}px "${font}"`;
+    ctx.font = `${weight}${mid}px "${font}"`;
     const m = ctx.measureText(text);
     const inkH = m.actualBoundingBoxAscent + m.actualBoundingBoxDescent;
     if (m.width <= maxWidth && (inkH > 0 ? inkH : mid) <= maxHeight) {

--- a/src/client/qr/thirdparty/qrcode.react/index.tsx
+++ b/src/client/qr/thirdparty/qrcode.react/index.tsx
@@ -110,10 +110,10 @@ interface QRProps {
    * modules (finders, timing, format/version info) square; 'text' splits each
    * module into a 3×3 sub-cell grid where the centre carries the QR value and
    * the outer eight cells show a rasterised text pattern; 'cutout' draws
-   * `rasterText` as solid black full modules with a narrow (half-module)
-   * white border separating it from the surrounding pattern, at whichever
-   * version high error correction naturally requires — sized so only a low
-   * amount of correction capacity remains spare afterwards.
+   * `rasterText` as real (non-pixelated) SVG text with a narrow (half-module)
+   * clear border, omitting any data module the text or border touch, at
+   * whichever version high error correction naturally requires — sized so
+   * only a low amount of correction capacity remains spare afterwards.
    * @defaultValue square
    */
   dotStyle?: 'square' | 'dot' | 'text' | 'cutout';
@@ -812,8 +812,8 @@ function CutoutQRCodeSVGDetails(
     ...otherProps
   } = props;
 
-  // The cutout re-encodes at a high enough version that its text (always
-  // solid black, full modules) and half-module white border fit with a low
+  // The cutout re-encodes at a high enough version that its text, drawn as
+  // real SVG text with a half-module clear border, fits with a low
   // remaining error-correction margin; when that hasn't resolved yet (or no
   // text is set), fall back to the plain square rendering of `details`.
   const cutout = useCutoutLayout(details, rasterText, rasterFont);
@@ -824,11 +824,11 @@ function CutoutQRCodeSVGDetails(
   // Quiet-zone frame: fills the margin band around the module grid.
   const bgPath = `M0,0 h${numCells}v${numCells}H0z`;
 
-  // The text's modules (and everything else) at native resolution; the
-  // fractional half-module border is a separate, finer-grained path drawn
-  // on top of it.
+  // Every module except those the text and its border clip, which are left
+  // light — the text itself is drawn as a real <text> element below, not
+  // approximated by forcing modules dark.
   const fgPath =
-    cutout?.blackPath ?? generatePath(details.cells, details.margin);
+    cutout?.patternPath ?? generatePath(details.cells, details.margin);
 
   return (
     <svg
@@ -848,11 +848,16 @@ function CutoutQRCodeSVGDetails(
       <path fill={bgColor} d={bgPath} shapeRendering="crispEdges" />
       <path fill={fgColor} d={fgPath} shapeRendering="crispEdges" />
       {!!cutout && (
-        <path
-          fill={bgColor}
-          d={cutout.borderOverlayPath}
-          shapeRendering="crispEdges"
-        />
+        <text
+          x={cutout.text.x}
+          y={cutout.text.y}
+          fontSize={cutout.text.fontSize}
+          fontFamily={`"${rasterFont}"`}
+          textAnchor="middle"
+          fill={fgColor}
+        >
+          {rasterText}
+        </text>
       )}
     </svg>
   );

--- a/src/client/qr/thirdparty/qrcode.react/index.tsx
+++ b/src/client/qr/thirdparty/qrcode.react/index.tsx
@@ -109,11 +109,11 @@ interface QRProps {
    * 'dot' renders data/alignment modules as circles while keeping structural
    * modules (finders, timing, format/version info) square; 'text' splits each
    * module into a 3×3 sub-cell grid where the centre carries the QR value and
-   * the outer eight cells show a rasterised text pattern; 'cutout' renders
-   * every module as a full square as normal, except that data modules inside
-   * `rasterText`'s silhouette (plus a small clear border) are forced light,
-   * leaving a legible hole in the pattern. The version is bumped as needed so
-   * enough error-correction budget remains spare after the cutout.
+   * the outer eight cells show a rasterised text pattern; 'cutout' draws
+   * `rasterText` as solid black full modules with a narrow (half-module)
+   * white border separating it from the surrounding pattern, at whichever
+   * version high error correction naturally requires — sized so only a low
+   * amount of correction capacity remains spare afterwards.
    * @defaultValue square
    */
   dotStyle?: 'square' | 'dot' | 'text' | 'cutout';
@@ -812,13 +812,11 @@ function CutoutQRCodeSVGDetails(
     ...otherProps
   } = props;
 
-  // The cutout may require a larger version than `details` to leave enough
-  // spare error-correction budget once the text's modules are cleared; when
-  // that hasn't resolved yet (or no text is set), fall back to the plain
-  // square rendering of `details` unchanged.
+  // The cutout re-encodes at a high enough version that its text (always
+  // solid black, full modules) and half-module white border fit with a low
+  // remaining error-correction margin; when that hasn't resolved yet (or no
+  // text is set), fall back to the plain square rendering of `details`.
   const cutout = useCutoutLayout(details, rasterText, rasterFont);
-  const cells = cutout?.cells ?? details.cells;
-  const margin = cutout?.margin ?? details.margin;
   const numCells = cutout?.numCells ?? details.numCells;
 
   const finalSize = numCells * cellSize;
@@ -826,10 +824,11 @@ function CutoutQRCodeSVGDetails(
   // Quiet-zone frame: fills the margin band around the module grid.
   const bgPath = `M0,0 h${numCells}v${numCells}H0z`;
 
-  // The cutout is already baked into `cells` — cleared modules are simply
-  // light, like any other light module — so the plain 'square' path
-  // generator produces full-square dark modules everywhere else.
-  const fgPath = generatePath(cells, margin);
+  // The text's modules (and everything else) at native resolution; the
+  // fractional half-module border is a separate, finer-grained path drawn
+  // on top of it.
+  const fgPath =
+    cutout?.blackPath ?? generatePath(details.cells, details.margin);
 
   return (
     <svg
@@ -848,6 +847,13 @@ function CutoutQRCodeSVGDetails(
       {!!title && <title>{title}</title>}
       <path fill={bgColor} d={bgPath} shapeRendering="crispEdges" />
       <path fill={fgColor} d={fgPath} shapeRendering="crispEdges" />
+      {!!cutout && (
+        <path
+          fill={bgColor}
+          d={cutout.borderOverlayPath}
+          shapeRendering="crispEdges"
+        />
+      )}
     </svg>
   );
 }

--- a/src/client/qr/thirdparty/qrcode.react/index.tsx
+++ b/src/client/qr/thirdparty/qrcode.react/index.tsx
@@ -18,6 +18,14 @@ import {
 
 import * as qrcodegen from '../qrcodegen';
 
+import { fitFontSize } from './fontFit';
+import { useCutoutLayout } from './textCutout';
+import {
+  SPEC_MARGIN_SIZE,
+  STRUCTURAL_TOP_ROWS,
+  STRUCTURAL_BOTTOM_ROWS,
+} from './constants';
+
 import type { QrCode, QrSegment } from '../qrcodegen';
 
 type Modules = ReturnType<qrcodegen.QrCode['getModules']>;
@@ -101,10 +109,14 @@ interface QRProps {
    * 'dot' renders data/alignment modules as circles while keeping structural
    * modules (finders, timing, format/version info) square; 'text' splits each
    * module into a 3×3 sub-cell grid where the centre carries the QR value and
-   * the outer eight cells show a rasterised text pattern.
+   * the outer eight cells show a rasterised text pattern; 'cutout' renders
+   * every module as a full square as normal, except that data modules inside
+   * `rasterText`'s silhouette (plus a small clear border) are forced light,
+   * leaving a legible hole in the pattern. The version is bumped as needed so
+   * enough error-correction budget remains spare after the cutout.
    * @defaultValue square
    */
-  dotStyle?: 'square' | 'dot' | 'text';
+  dotStyle?: 'square' | 'dot' | 'text' | 'cutout';
   /**
    * Radius of each dot in dot mode, as a fraction of the module size (0–0.5).
    * A value of 0.5 fills the full cell; 0.25 (default) renders at half diameter.
@@ -124,8 +136,6 @@ const DEFAULT_LEVEL: ErrorCorrectionLevel = 'L';
 const DEFAULT_BGCOLOR = '#FFFFFF';
 const DEFAULT_FGCOLOR = '#000000';
 const DEFAULT_MINVERSION = 1;
-
-const SPEC_MARGIN_SIZE = 4;
 
 // Modified to be exported so the QR debugger can render decoded matrices.
 export function generatePath(modules: Modules, margin = 0): string {
@@ -271,11 +281,6 @@ function generateDotPath(
   return ops.join('');
 }
 
-// Structural zones: top 9 rows (TL+TR finders + format info) and bottom 8 rows
-// (BL finder + format info). Interior data rows: 9 … size−9 = size−17 rows total.
-const STRUCTURAL_TOP_ROWS = 9;
-const STRUCTURAL_BOTTOM_ROWS = 8;
-
 // Renders rasterText onto an off-screen canvas covering only the interior data
 // area (between the locator squares): width size*3, height (size−17)*3.
 // Returns null while loading or when rasterText is empty.
@@ -320,24 +325,11 @@ function useRasterPixels(
 
       // Largest font where the actual ink bounds fit — not the nominal em size,
       // so text without descenders (e.g. "QR") can use a larger font.
-      let lo = 1,
-        hi = Math.max(cw, ch) * 2;
-      while (lo < hi - 1) {
-        const mid = (lo + hi) >> 1;
-        ctx.font = `bold ${mid}px "${rasterFont}"`;
-        const m = ctx.measureText(rasterText);
-        const inkH = m.actualBoundingBoxAscent + m.actualBoundingBoxDescent;
-        // Fall back to font size when actual bounds are unavailable (e.g. jsdom)
-        if (m.width <= cw && (inkH > 0 ? inkH : mid) <= ch) {
-          lo = mid;
-        } else {
-          hi = mid;
-        }
-      }
+      const fontSize = fitFontSize(ctx, rasterText, rasterFont, cw, ch);
 
       // Center by ink bounds rather than the em box so the visual weight sits
       // in the middle of the data region regardless of descenders.
-      ctx.font = `bold ${lo}px "${rasterFont}"`;
+      ctx.font = `bold ${fontSize}px "${rasterFont}"`;
       const fm = ctx.measureText(rasterText);
       const inkCy =
         fm.actualBoundingBoxAscent > 0
@@ -585,8 +577,10 @@ export function QRCodeSVGDetails({
     <SquareQRCodeSVGDetails dotStyle="square" {...otherProps} />
   ) : dotStyle === 'dot' ? (
     <DotQRCodeSVGDetails dotStyle="dot" {...otherProps} />
-  ) : (
+  ) : dotStyle === 'text' ? (
     <TextQRCodeSVGDetails dotStyle="text" {...otherProps} />
+  ) : (
+    <CutoutQRCodeSVGDetails dotStyle="cutout" {...otherProps} />
   );
 }
 
@@ -793,6 +787,67 @@ function TextQRCodeSVGDetails(
       <path fill={bgColor} d={bgPath} shapeRendering="crispEdges" />
       <path fill={fgColor} d={fgPath} shapeRendering="crispEdges" />
       <path fill={fgColor} d={textPath} shapeRendering="crispEdges" />
+    </svg>
+  );
+}
+
+function CutoutQRCodeSVGDetails(
+  props: Omit<QRPropsSVG, 'value' | 'dotStyle'> & {
+    details: QrCodeDetails;
+    ref?: Ref<SVGSVGElement> | undefined;
+    dotStyle?: 'cutout';
+  },
+): JSX.Element {
+  const {
+    details,
+    bgColor = DEFAULT_BGCOLOR,
+    fgColor = DEFAULT_FGCOLOR,
+    title,
+    cellSize = DEFAULT_CELL_SIZE,
+    rasterText = '',
+    rasterFont = 'Impact',
+    dotStyle: _dotStyle,
+    dotRadius: _dotRadius,
+    ref,
+    ...otherProps
+  } = props;
+
+  // The cutout may require a larger version than `details` to leave enough
+  // spare error-correction budget once the text's modules are cleared; when
+  // that hasn't resolved yet (or no text is set), fall back to the plain
+  // square rendering of `details` unchanged.
+  const cutout = useCutoutLayout(details, rasterText, rasterFont);
+  const cells = cutout?.cells ?? details.cells;
+  const margin = cutout?.margin ?? details.margin;
+  const numCells = cutout?.numCells ?? details.numCells;
+
+  const finalSize = numCells * cellSize;
+
+  // Quiet-zone frame: fills the margin band around the module grid.
+  const bgPath = `M0,0 h${numCells}v${numCells}H0z`;
+
+  // The cutout is already baked into `cells` — cleared modules are simply
+  // light, like any other light module — so the plain 'square' path
+  // generator produces full-square dark modules everywhere else.
+  const fgPath = generatePath(cells, margin);
+
+  return (
+    <svg
+      height={finalSize}
+      width={finalSize}
+      style={{
+        containIntrinsicHeight: `${finalSize}px`,
+        containIntrinsicWidth: `${finalSize}px`,
+        contain: 'strict',
+      }}
+      viewBox={`0 0 ${numCells} ${numCells}`}
+      ref={ref}
+      role="img"
+      {...otherProps}
+    >
+      {!!title && <title>{title}</title>}
+      <path fill={bgColor} d={bgPath} shapeRendering="crispEdges" />
+      <path fill={fgColor} d={fgPath} shapeRendering="crispEdges" />
     </svg>
   );
 }

--- a/src/client/qr/thirdparty/qrcode.react/textCutout.ts
+++ b/src/client/qr/thirdparty/qrcode.react/textCutout.ts
@@ -13,6 +13,15 @@
  * running this project's QR decoder over the resulting matrix before it's
  * accepted — the same simulation a real scan would produce, not a guess
  * about how much can safely be erased.
+ *
+ * The cutout must not swallow the error-correction budget the user selected
+ * in "Min error correction" — that budget is meant for real-world scan
+ * damage, not for a hole the generator put there on purpose. So at least
+ * half of the selected level's own nominal correction capacity is always
+ * kept spare afterwards (see KEEP_FRACTION), and extra room for a bigger
+ * cutout is found "for free" wherever possible first by raising the
+ * error-correction level at the same version (more ECC codewords, no
+ * bigger symbol), and only then by raising the version.
  */
 
 import { useEffect, useState } from 'react';
@@ -24,10 +33,10 @@ import {
   STRUCTURAL_BOTTOM_ROWS,
 } from './constants';
 
-import type { Ecc } from '@/client/qr/thirdparty/qrcodegen/Ecc';
 import type { QrSegment } from '@/client/qr/thirdparty/qrcodegen/qrSegment';
 import type { ModuleRegion } from '@/client/qr/decoder/types';
 
+import { Ecc } from '@/client/qr/thirdparty/qrcodegen/Ecc';
 import { QrCode } from '@/client/qr/thirdparty/qrcodegen/qrCode';
 import { functionModuleMap } from '@/client/qr/decoder/functionModules';
 import {
@@ -37,26 +46,38 @@ import {
 } from '@/client/qr/decoder/codewords';
 import { rsDecode } from '@/client/qr/decoder/reedSolomon';
 
-// Below this height (in modules) the cutout is no longer legible, so a
-// smaller height is never attempted — the version is bumped instead.
-const MIN_TEXT_HEIGHT_MODULES = 6;
+// Below this height (in modules) the cutout is not attempted — a smaller
+// glyph than this is illegible however clean the render, and blocky/heavy
+// display fonts (Impact and friends) tend to blob together at this scale
+// once dilated for the border.
+const MIN_TEXT_HEIGHT_MODULES = 8;
 
-// Once a version yields at least this tall a cutout, stop bumping the
-// version further — anything beyond this is a diminishing-returns trade of
-// a bigger symbol for marginally clearer text.
-const COMFORTABLE_TEXT_HEIGHT_MODULES = 14;
+// Once a version/level combination yields at least this tall a cutout, stop
+// searching further — this is comfortably legible for a couple of
+// characters, and anything beyond is a diminishing-returns trade of a
+// bigger symbol for marginally clearer text.
+const COMFORTABLE_TEXT_HEIGHT_MODULES = 20;
 
 // Radius (in modules) of the clear halo drawn around each glyph's ink,
 // forming the "white border" that keeps the QR noise clear of the text.
 const BORDER_MODULES = 1;
 
-// Fraction of each Reed–Solomon block's correction capacity the cutout is
-// allowed to spend, leaving the remainder as a margin for real-world scan
-// damage (dirt, glare, print defects, perspective distortion, ...).
-const MAX_CAPACITY_FRACTION = 0.7;
+// However the cutout's cost is funded (see fitCutout's doc comment), at
+// least this fraction of the selected level's own nominal correction
+// capacity must remain spare afterwards — the "small margin" for real-world
+// scan damage (dirt, glare, print defects, perspective distortion, ...)
+// that the cutout must never fully spend.
+const KEEP_FRACTION = 0.5;
+
+// Every level from the user's selection upward is tried (at the same
+// version) before the version itself is bumped, since a higher level costs
+// nothing in symbol size and — because the required spare is always pegged
+// to the *selected* level's own capacity, never the escalated one — funds
+// a bigger cutout without eroding the guaranteed floor any further.
+const LEVELS = [Ecc.LOW, Ecc.MEDIUM, Ecc.QUARTILE, Ecc.HIGH];
 
 // Safety cap on how many versions we'll try before giving up.
-const MAX_VERSION_ATTEMPTS = 20;
+const MAX_VERSION_ATTEMPTS = 30;
 
 export interface CutoutLayout {
   cells: boolean[][];
@@ -68,6 +89,34 @@ export interface CutoutLayout {
 interface CutoutSource {
   qrcode: QrCode;
   segments: readonly QrSegment[];
+}
+
+// Total codewords correctable across every Reed–Solomon block at this
+// version/level — a pure function of the standard tables, independent of
+// what's actually encoded, so it can be used as a reference even for a
+// level/version combination nothing has been encoded at.
+function totalCorrectableCapacity(version: number, ecl: Ecc): number {
+  const structure = getBlockStructure(version, ecl);
+  return structure.blocks.reduce(
+    (sum, block) => sum + Math.floor(block.eccLen / 2),
+    0,
+  );
+}
+
+// Re-encodes `segments` at an exact (version, level), or returns null if the
+// data doesn't fit that combination (never boosts the level or version
+// beyond what's asked, since the caller is deliberately probing a specific
+// combination).
+function tryEncode(
+  segments: readonly QrSegment[],
+  level: Ecc,
+  version: number,
+): QrCode | null {
+  try {
+    return QrCode.encodeSegments(segments, level, version, version, -1, false);
+  } catch {
+    return null;
+  }
 }
 
 // Forces every module inside `interiorClear` light, but only where that
@@ -123,7 +172,9 @@ function dilate(
 }
 
 // Rasterises `text` centred in a `width`×`height` module-resolution canvas,
-// returning a boolean ink mask (true = dark/glyph pixel).
+// returning a boolean ink mask (true = dark/glyph pixel). Rendered at the
+// font's natural weight (not synthetically bolded) — see fitFontSize's doc
+// for why that matters here specifically.
 function rasterInkMask(
   ctx: CanvasRenderingContext2D,
   text: string,
@@ -137,7 +188,7 @@ function rasterInkMask(
   ctx.fillStyle = '#000000';
   ctx.textBaseline = 'alphabetic';
   ctx.textAlign = 'center';
-  ctx.font = `bold ${fontSize}px "${font}"`;
+  ctx.font = `${fontSize}px "${font}"`;
 
   const m = ctx.measureText(text);
   const inkCy =
@@ -160,33 +211,37 @@ function rasterInkMask(
 }
 
 // Runs this project's own QR decoder over the candidate matrix and checks
-// that every Reed–Solomon block both decodes and keeps at least
-// (1 − MAX_CAPACITY_FRACTION) of its correction capacity spare. This is the
-// same check a real scanner's error correction would perform, so it directly
-// answers "would a reader still recover this?" rather than approximating it
-// from module counts.
+// that every Reed–Solomon block decodes, and that the total spare
+// correction capacity left afterwards is at least `requiredSpare` — the
+// same check a real scanner's error correction would perform, so it
+// directly answers "would a reader still recover this, with the selected
+// level's protection intact?" rather than approximating it from module
+// counts.
 function verifyDecodable(
   clearedCells: readonly (readonly boolean[])[],
   version: number,
   mask: number,
-  ecl: Ecc,
+  candidateLevel: Ecc,
+  requiredSpare: number,
 ): boolean {
-  const structure = getBlockStructure(version, ecl);
+  const structure = getBlockStructure(version, candidateLevel);
   const { codewords } = extractCodewords(
     clearedCells.map((row) => [...row]),
     version,
     mask,
   );
   const { blocks } = deinterleave(codewords, structure);
-  return blocks.every((block, i) => {
+
+  let spare = 0;
+  for (const [i, block] of blocks.entries()) {
     const { eccLen } = structure.blocks[i];
     const result = rsDecode(block, eccLen);
     if (!result) {
       return false;
     }
-    const maxAllowed = Math.floor((eccLen / 2) * MAX_CAPACITY_FRACTION);
-    return result.errorPositions.length <= maxAllowed;
-  });
+    spare += Math.floor(eccLen / 2) - result.errorPositions.length;
+  }
+  return spare >= requiredSpare;
 }
 
 interface TextFit {
@@ -194,14 +249,15 @@ interface TextFit {
   height: number;
 }
 
-// Finds the tallest legible cutout that still verifies as decodable with
-// margin at this QR version, or null if even the minimum legible size
-// doesn't leave enough error-correction budget spare.
+// Finds the tallest legible cutout at this exact (version, level) that still
+// leaves `requiredSpare` correction capacity, or null if even the minimum
+// legible size doesn't.
 function fitTextAtVersion(
   qrcode: QrCode,
   rasterText: string,
   rasterFont: string,
   ctx: CanvasRenderingContext2D,
+  requiredSpare: number,
 ): TextFit | null {
   const cells = qrcode.getModules();
   const size = cells.length;
@@ -227,6 +283,7 @@ function fitTextAtVersion(
       rasterFont,
       interiorWidth - 2 * BORDER_MODULES,
       targetHeight,
+      false,
     );
     const inkMask = rasterInkMask(
       ctx,
@@ -243,13 +300,14 @@ function fitTextAtVersion(
       version,
       qrcode.mask,
       qrcode.errorCorrectionLevel,
+      requiredSpare,
     )
       ? clearMask
       : null;
   };
 
   // The smallest legible size sets the floor: if even that doesn't leave
-  // enough spare capacity, no size at this version will.
+  // enough spare capacity, no size at this version/level will.
   const minResult = tryHeight(MIN_TEXT_HEIGHT_MODULES);
   if (!minResult) {
     return null;
@@ -277,12 +335,19 @@ function fitTextAtVersion(
   };
 }
 
-// Tries the cutout at increasing QR versions (re-encoding the same segments
-// and error-correction level each time), since a fixed-size text patch
-// becomes a proportionally smaller — and so more easily correctable —
-// erasure as the symbol grows. Keeps bumping until a comfortably legible
-// height is reached, then uses the tallest layout found across all versions
-// tried (never returning a shorter cutout for a version tried later).
+// Tries the cutout at the selected error-correction level first, then at
+// each higher level (still at the same version — free extra budget), then
+// bumps the version and repeats, until a comfortably legible height is
+// reached or the version cap is exhausted.
+//
+// Whichever (version, level) combination actually ends up drawn, the
+// requirement checked at every step is the same: at least KEEP_FRACTION of
+// the *selected* level's own nominal correction capacity for that version —
+// never the escalated level's, so escalating only ever funds a bigger
+// cutout, it never lets the guaranteed floor slip. Escalating for free (a
+// higher level at the same version, or more raw codewords at a bigger one)
+// means the cutout increasingly comes out of that extra capacity rather
+// than the user's selected level's own share of it.
 function fitCutout(
   baseQrcode: QrCode,
   segments: readonly QrSegment[],
@@ -299,40 +364,54 @@ function fitCutout(
     return null;
   }
 
-  let qrcode = baseQrcode;
+  const targetLevel = baseQrcode.errorCorrectionLevel;
+  const levelsToTry = LEVELS.slice(targetLevel.ordinal);
+
   let bestLayout: CutoutLayout | null = null;
   let bestHeight = 0;
 
-  for (let attempt = 0; attempt < MAX_VERSION_ATTEMPTS; attempt++) {
-    const fit = fitTextAtVersion(qrcode, rasterText, rasterFont, ctx);
-    if (fit && fit.height > bestHeight) {
-      bestHeight = fit.height;
-      bestLayout = {
-        cells: fit.clearedCells,
-        version: qrcode.version,
-        margin: SPEC_MARGIN_SIZE,
-        numCells: fit.clearedCells.length + SPEC_MARGIN_SIZE * 2,
-      };
+  for (
+    let version = baseQrcode.version, attempt = 0;
+    attempt < MAX_VERSION_ATTEMPTS;
+    version++, attempt++
+  ) {
+    const requiredSpare = Math.ceil(
+      totalCorrectableCapacity(version, targetLevel) * KEEP_FRACTION,
+    );
+
+    for (const level of levelsToTry) {
+      const qrcode =
+        level.ordinal === targetLevel.ordinal && version === baseQrcode.version
+          ? baseQrcode
+          : tryEncode(segments, level, version);
+      if (!qrcode) {
+        continue;
+      }
+
+      const fit = fitTextAtVersion(
+        qrcode,
+        rasterText,
+        rasterFont,
+        ctx,
+        requiredSpare,
+      );
+      if (fit && fit.height > bestHeight) {
+        bestHeight = fit.height;
+        bestLayout = {
+          cells: fit.clearedCells,
+          version,
+          margin: SPEC_MARGIN_SIZE,
+          numCells: fit.clearedCells.length + SPEC_MARGIN_SIZE * 2,
+        };
+      }
     }
 
     if (bestHeight >= COMFORTABLE_TEXT_HEIGHT_MODULES) {
       break;
     }
-
-    const nextVersion = qrcode.version + 1;
-    if (nextVersion > QrCode.MAX_VERSION) {
+    if (version + 1 > QrCode.MAX_VERSION) {
       break;
     }
-    // boostEcl: false — keep the level the user asked for exactly, rather
-    // than silently upgrading it now that a bigger version has spare room.
-    qrcode = QrCode.encodeSegments(
-      segments,
-      qrcode.errorCorrectionLevel,
-      nextVersion,
-      nextVersion,
-      -1,
-      false,
-    );
   }
 
   return bestLayout;
@@ -352,7 +431,7 @@ export function useCutoutLayout(
     let cancelled = false;
 
     async function run() {
-      await document.fonts.load(`bold 72px "${rasterFont}"`);
+      await document.fonts.load(`72px "${rasterFont}"`);
       if (cancelled) {
         return;
       }

--- a/src/client/qr/thirdparty/qrcode.react/textCutout.ts
+++ b/src/client/qr/thirdparty/qrcode.react/textCutout.ts
@@ -1,8 +1,11 @@
 /*
- * Implements the 'cutout' dot style: `rasterText` drawn as solid black full
- * modules, with a narrow (half-module) white border separating it from the
- * surrounding pattern, with every other module left as a normal full
- * square.
+ * Implements the 'cutout' dot style: `rasterText` drawn as real, smoothly
+ * rendered SVG text (not quantised to the module grid), with a narrow
+ * (half-module) white border separating it from the surrounding pattern.
+ * Every QR module that doesn't clip that text-plus-border region is left as
+ * a normal full square; any module that does is simply not drawn at all —
+ * the text element and the plain white background underneath it are what
+ * shows through instead.
  *
  * Unlike the decorative 'text' style (which only ever redraws the true QR
  * value, just visually dressed up), this style actually overwrites modules
@@ -13,7 +16,9 @@
  * at all), and because every candidate layout is verified by literally
  * running this project's QR decoder over the resulting matrix before it's
  * accepted — the same simulation a real scan would produce, not a guess
- * about how much can safely be overwritten.
+ * about how much can safely be overwritten. The verification always
+ * assumes the whole clipped region reads back as light, which is exactly
+ * what's actually drawn there other than the text glyphs themselves.
  *
  * The style always encodes at high error correction — that's the biggest
  * error budget the format has — and then re-encodes at successively higher
@@ -48,12 +53,8 @@ import { rsDecode } from '@/client/qr/decoder/reedSolomon';
 // glyph than this is illegible however clean the render.
 const MIN_TEXT_HEIGHT_MODULES = 8;
 
-// Radius (in whole modules) of the ring around the text's ink treated as
-// "at risk" for the error-correction budget check. The border actually
-// drawn is only half a module wide (see generateBorderOverlayPath) —
-// checking against a full module is deliberately more pessimistic than
-// what's really overwritten, which only widens the safety margin.
-const RING_RADIUS_MODULES = 1;
+// Width, in modules, of the white border kept clear around the text's ink.
+const BORDER_WIDTH_MODULES = 0.5;
 
 // The error-correction level is always the format's strongest, giving the
 // text and border the biggest possible budget to draw within.
@@ -71,10 +72,14 @@ export interface CutoutLayout {
   version: number;
   margin: number;
   numCells: number;
-  /** Full pattern at native module resolution, with the text's ink forced black. */
-  blackPath: string;
-  /** Half-module-wide white border around the text, drawn on top of blackPath. */
-  borderOverlayPath: string;
+  /** The surrounding QR pattern, with every module clipping the text+border left light. */
+  patternPath: string;
+  /** Where to draw the real SVG <text> glyph, in the same coordinate space as patternPath. */
+  text: {
+    x: number;
+    y: number;
+    fontSize: number;
+  };
 }
 
 interface CutoutSource {
@@ -105,25 +110,21 @@ function tryEncode(
   }
 }
 
-// Generates an SVG fill path for a boolean grid. Grid cell (row, col)
-// occupies the square [offsetX+col*scale, offsetY+row*scale] sized
-// scale×scale — filled cells merge seamlessly at any scale, unlike a
-// stroked outline, which is what lets the border be drawn at a finer
-// (half-module) scale than the text without visible seams between rows.
+// Generates an SVG fill path for a boolean grid at native module scale.
+// Adjacent filled cells merge seamlessly since this is a fill, not a
+// stroked outline.
 function generateFillPath(
   mask: readonly (readonly boolean[])[],
   offsetX: number,
   offsetY: number,
-  scale: number,
 ): string {
   const ops: string[] = [];
   for (const [row, cells] of mask.entries()) {
     let start: number | null = null;
     const emit = (from: number, to: number): void => {
-      const x = offsetX + from * scale;
-      const y = offsetY + row * scale;
-      const w = (to - from) * scale;
-      ops.push(`M${x},${y}h${w}v${scale}H${x}z`);
+      ops.push(
+        `M${offsetX + from},${offsetY + row}h${to - from}v1H${offsetX + from}z`,
+      );
     };
     for (const [col, cell] of cells.entries()) {
       if (cell && start === null) {
@@ -140,13 +141,10 @@ function generateFillPath(
   return ops.join('');
 }
 
-// Chebyshev (square) dilation, used both to build the full-module "at risk"
-// ring for the budget check and, on an upsampled grid, the half-module
-// border ring for rendering.
-function dilate(
-  mask: readonly (readonly boolean[])[],
-  radius: number,
-): boolean[][] {
+// Chebyshev (square) dilation by one cell of whatever grid it's given —
+// used on a 2×-supersampled ink grid so a single dilation is exactly a
+// half-module grow.
+function dilateBy1(mask: readonly (readonly boolean[])[]): boolean[][] {
   const height = mask.length;
   const width = mask[0]?.length ?? 0;
   const result: boolean[][] = Array.from({ length: height }, () =>
@@ -157,12 +155,12 @@ function dilate(
       if (!isSet) {
         continue;
       }
-      for (let dy = -radius; dy <= radius; dy++) {
+      for (let dy = -1; dy <= 1; dy++) {
         const ny = y + dy;
         if (ny < 0 || ny >= height) {
           continue;
         }
-        for (let dx = -radius; dx <= radius; dx++) {
+        for (let dx = -1; dx <= 1; dx++) {
           const nx = x + dx;
           if (nx >= 0 && nx < width) {
             result[ny][nx] = true;
@@ -189,10 +187,13 @@ function upsample2x(mask: readonly (readonly boolean[])[]): boolean[][] {
 }
 
 // Rasterises `text` centred in a `width`×`height` module-resolution canvas,
-// returning a boolean ink mask (true = dark/glyph pixel). Rendered at the
-// font's natural weight (not synthetically bolded), which keeps already-
-// heavy display fonts (Impact and friends) from blobbing strokes together
-// at this resolution.
+// returning a boolean ink mask (true = dark/glyph pixel) — used only to work
+// out which modules the text's ink and border actually reach, never for the
+// visible glyph itself (that's drawn as real, smoothly rendered SVG text
+// using this same font/size/position). Rendered at the font's natural
+// weight (not synthetically bolded), which keeps already-heavy display
+// fonts (Impact and friends) from blobbing strokes together once dilated
+// for the border.
 function rasterInkMask(
   ctx: CanvasRenderingContext2D,
   text: string,
@@ -207,14 +208,7 @@ function rasterInkMask(
   ctx.textBaseline = 'alphabetic';
   ctx.textAlign = 'center';
   ctx.font = `${fontSize}px "${font}"`;
-
-  const m = ctx.measureText(text);
-  const inkCy =
-    m.actualBoundingBoxAscent > 0
-      ? height / 2 +
-        (m.actualBoundingBoxAscent - m.actualBoundingBoxDescent) / 2
-      : height / 2;
-  ctx.fillText(text, width / 2, inkCy);
+  ctx.fillText(text, width / 2, textBaselineY(ctx, text, height));
 
   const { data } = ctx.getImageData(0, 0, width, height);
   const mask: boolean[][] = [];
@@ -228,34 +222,57 @@ function rasterInkMask(
   return mask;
 }
 
-// Forces every module inside `ink` black and every module inside `ring`
-// (but not already ink) white, except structural modules, which are never
-// touched. Used only for the decodability check — a full module's worth of
-// "at risk" ring, deliberately more pessimistic than the half-module border
-// actually drawn.
-function withInkAndRingForced(
+// Baseline y-coordinate that centres `text`'s actual ink bounds (not its
+// nominal em box) within a box `height` tall — shared between the mask
+// rasterisation above and the real SVG <text> element's `y`, so the two
+// line up exactly.
+function textBaselineY(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  height: number,
+): number {
+  const m = ctx.measureText(text);
+  return m.actualBoundingBoxAscent > 0
+    ? height / 2 + (m.actualBoundingBoxAscent - m.actualBoundingBoxDescent) / 2
+    : height / 2;
+}
+
+// True for every module whose square overlaps the text's ink or its
+// half-module border, at full precision (via a 2×-supersampled grid) rather
+// than the ink mask's own module-resolution grid — a module counts as
+// clipped if *any* part of it falls in the zone, not just its centre.
+function computeClipZone(ink: readonly (readonly boolean[])[]): boolean[][] {
+  const grown = dilateBy1(upsample2x(ink));
+  const height = ink.length;
+  const width = ink[0]?.length ?? 0;
+  return Array.from({ length: height }, (_, y) =>
+    Array.from(
+      { length: width },
+      (_, x) =>
+        grown[2 * y]?.[2 * x] ||
+        grown[2 * y]?.[2 * x + 1] ||
+        grown[2 * y + 1]?.[2 * x] ||
+        grown[2 * y + 1]?.[2 * x + 1],
+    ),
+  );
+}
+
+// Leaves every module untouched except data modules clipped by the text or
+// its border, which are forced light — never dark, whatever their true
+// value, since only the separately drawn text glyph is allowed to be dark
+// there.
+function withClipZoneForced(
   cells: readonly (readonly boolean[])[],
-  ink: readonly (readonly boolean[])[],
-  ring: readonly (readonly boolean[])[],
+  clipZone: readonly (readonly boolean[])[],
   fmap: readonly (readonly ModuleRegion[])[],
   interiorTop: number,
 ): boolean[][] {
   return cells.map((row, y) => {
     const my = y - interiorTop;
-    const inkRow = my >= 0 && my < ink.length ? ink[my] : null;
-    const ringRow = my >= 0 && my < ring.length ? ring[my] : null;
-    return row.map((cell, x) => {
-      if (fmap[y][x] !== 'data') {
-        return cell;
-      }
-      if (inkRow?.[x]) {
-        return true;
-      }
-      if (ringRow?.[x]) {
-        return false;
-      }
-      return cell;
-    });
+    const zoneRow = my >= 0 && my < clipZone.length ? clipZone[my] : null;
+    return row.map((cell, x) =>
+      zoneRow?.[x] && fmap[y][x] === 'data' ? false : cell,
+    );
   });
 }
 
@@ -292,9 +309,7 @@ function verifyDecodable(
 }
 
 interface TextFit {
-  ink: boolean[][];
-  interiorTop: number;
-  fmap: ModuleRegion[][];
+  fontSize: number;
   height: number;
 }
 
@@ -316,7 +331,7 @@ function fitTextAtVersion(
   const interiorTop = STRUCTURAL_TOP_ROWS;
   const interiorWidth = size;
   const interiorHeight = size - STRUCTURAL_TOP_ROWS - STRUCTURAL_BOTTOM_ROWS;
-  const maxTextHeight = interiorHeight - 2 * RING_RADIUS_MODULES;
+  const maxTextHeight = interiorHeight - 2 * BORDER_WIDTH_MODULES;
 
   if (maxTextHeight < MIN_TEXT_HEIGHT_MODULES) {
     return null;
@@ -325,12 +340,12 @@ function fitTextAtVersion(
   ctx.canvas.width = interiorWidth;
   ctx.canvas.height = interiorHeight;
 
-  const tryHeight = (targetHeight: number): boolean[][] | null => {
+  const tryHeight = (targetHeight: number): number | null => {
     const fontSize = fitFontSize(
       ctx,
       rasterText,
       rasterFont,
-      interiorWidth - 2 * RING_RADIUS_MODULES,
+      interiorWidth - 2 * BORDER_WIDTH_MODULES,
       targetHeight,
       false,
     );
@@ -342,92 +357,88 @@ function fitTextAtVersion(
       interiorWidth,
       interiorHeight,
     );
-    const ring = dilate(ink, RING_RADIUS_MODULES).map((row, y) =>
-      row.map((cell, x) => cell && !ink[y]?.[x]),
-    );
-    const clearedCells = withInkAndRingForced(
-      cells,
-      ink,
-      ring,
-      fmap,
-      interiorTop,
-    );
+    const clipZone = computeClipZone(ink);
+    const clearedCells = withClipZoneForced(cells, clipZone, fmap, interiorTop);
     return verifyDecodable(clearedCells, version, qrcode.mask, requiredSpare)
-      ? ink
+      ? fontSize
       : null;
   };
 
   // The smallest legible size sets the floor: if even that doesn't leave
   // enough spare capacity, no size at this version will.
   const minResult = tryHeight(MIN_TEXT_HEIGHT_MODULES);
-  if (!minResult) {
+  if (minResult === null) {
     return null;
   }
 
   let lo = MIN_TEXT_HEIGHT_MODULES;
   let hi = maxTextHeight;
-  let best = minResult;
+  let bestFontSize = minResult;
   let bestHeight = MIN_TEXT_HEIGHT_MODULES;
   while (lo < hi) {
     const mid = Math.ceil((lo + hi) / 2);
     const candidate = tryHeight(mid);
-    if (candidate) {
-      lo = mid;
-      best = candidate;
-      bestHeight = mid;
-    } else {
+    if (candidate === null) {
       hi = mid - 1;
+    } else {
+      lo = mid;
+      bestFontSize = candidate;
+      bestHeight = mid;
     }
   }
 
-  return { ink: best, interiorTop, fmap, height: bestHeight };
+  return { fontSize: bestFontSize, height: bestHeight };
 }
 
-// The text's ink, forced black, at native module resolution — everything
-// else in `cells` (including the border ring) is left exactly as encoded,
-// since the border overlay handles clearing it separately.
-function buildBlackPath(
-  cells: readonly (readonly boolean[])[],
+// Builds the final layout for the winning (version, fontSize): the
+// surrounding pattern with the text+border's clip zone left light, and
+// where to draw the real SVG <text> glyph on top of it.
+function buildLayout(
+  qrcode: QrCode,
   fit: TextFit,
-  margin: number,
-): string {
-  const { ink, fmap, interiorTop } = fit;
-  const withInk = cells.map((row, y) => {
-    const my = y - interiorTop;
-    const inkRow = my >= 0 && my < ink.length ? ink[my] : null;
-    return row.map((cell, x) =>
-      inkRow?.[x] && fmap[y][x] === 'data' ? true : cell,
-    );
-  });
-  return generateFillPath(withInk, margin, margin, 1);
-}
+  rasterText: string,
+  rasterFont: string,
+  ctx: CanvasRenderingContext2D,
+): CutoutLayout {
+  const cells = qrcode.getModules();
+  const size = cells.length;
+  const fmap = functionModuleMap(qrcode.version);
 
-// A precise half-module-wide white border: the ink mask grown by exactly
-// one subcell on a 2×-supersampled grid, restricted to data modules. Drawn
-// on top of the black text (which re-covers everything inside the original
-// ink boundary), so only the outer half-module ring stays visible.
-function buildBorderOverlayPath(fit: TextFit, margin: number): string {
-  const { ink, fmap, interiorTop } = fit;
-  const ink2x = upsample2x(ink);
-  // dilate() keeps the original ink subcells set too, so subtract ink2x back
-  // out — the overlay must be only the ring, or it would paint over (and
-  // hide) the black text drawn on top of it.
-  const ring = dilate(ink2x, 1).map((row, sy) =>
-    row.map((isSet, sx) => isSet && !ink2x[sy]?.[sx]),
+  const interiorTop = STRUCTURAL_TOP_ROWS;
+  const interiorWidth = size;
+  const interiorHeight = size - STRUCTURAL_TOP_ROWS - STRUCTURAL_BOTTOM_ROWS;
+
+  ctx.canvas.width = interiorWidth;
+  ctx.canvas.height = interiorHeight;
+  const ink = rasterInkMask(
+    ctx,
+    rasterText,
+    rasterFont,
+    fit.fontSize,
+    interiorWidth,
+    interiorHeight,
   );
-  for (const [sy, row] of ring.entries()) {
-    for (const [sx, isSet] of row.entries()) {
-      if (!isSet) {
-        continue;
-      }
-      const y = Math.floor(sy / 2) + interiorTop;
-      const x = Math.floor(sx / 2);
-      if (fmap[y]?.[x] !== 'data') {
-        row[sx] = false;
-      }
-    }
-  }
-  return generateFillPath(ring, margin, margin + interiorTop, 0.5);
+  const clipZone = computeClipZone(ink);
+  const clearedCells = withClipZoneForced(cells, clipZone, fmap, interiorTop);
+
+  ctx.font = `${fit.fontSize}px "${rasterFont}"`;
+  const baselineY = textBaselineY(ctx, rasterText, interiorHeight);
+
+  return {
+    version: qrcode.version,
+    margin: SPEC_MARGIN_SIZE,
+    numCells: size + SPEC_MARGIN_SIZE * 2,
+    patternPath: generateFillPath(
+      clearedCells,
+      SPEC_MARGIN_SIZE,
+      SPEC_MARGIN_SIZE,
+    ),
+    text: {
+      x: SPEC_MARGIN_SIZE + interiorWidth / 2,
+      y: SPEC_MARGIN_SIZE + interiorTop + baselineY,
+      fontSize: fit.fontSize,
+    },
+  };
 }
 
 // Always encodes at high error correction, then tries successively higher
@@ -472,14 +483,7 @@ function fitCutout(
       requiredSpare,
     );
     if (fit) {
-      const cells = qrcode.getModules();
-      return {
-        version: qrcode.version,
-        margin: SPEC_MARGIN_SIZE,
-        numCells: cells.length + SPEC_MARGIN_SIZE * 2,
-        blackPath: buildBlackPath(cells, fit, SPEC_MARGIN_SIZE),
-        borderOverlayPath: buildBorderOverlayPath(fit, SPEC_MARGIN_SIZE),
-      };
+      return buildLayout(qrcode, fit, rasterText, rasterFont, ctx);
     }
 
     const nextVersion = qrcode.version + 1;

--- a/src/client/qr/thirdparty/qrcode.react/textCutout.ts
+++ b/src/client/qr/thirdparty/qrcode.react/textCutout.ts
@@ -1,0 +1,371 @@
+/*
+ * Implements the 'cutout' dot style: a legible hole shaped like `rasterText`
+ * punched into the data modules, with every other module left as a normal
+ * full square.
+ *
+ * Unlike the decorative 'text' style (which only ever redraws the true QR
+ * value, just visually dressed up), this style actually forces modules
+ * light regardless of their encoded value — a scanner reading those modules
+ * sees plain white, exactly like any other reader would. That's only safe
+ * because the affected modules are always Reed–Solomon data/ECC modules
+ * (never finder/timing/alignment/format/version, which carry no redundancy
+ * at all), and because every candidate layout is verified by literally
+ * running this project's QR decoder over the resulting matrix before it's
+ * accepted — the same simulation a real scan would produce, not a guess
+ * about how much can safely be erased.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { fitFontSize } from './fontFit';
+import {
+  SPEC_MARGIN_SIZE,
+  STRUCTURAL_TOP_ROWS,
+  STRUCTURAL_BOTTOM_ROWS,
+} from './constants';
+
+import type { Ecc } from '@/client/qr/thirdparty/qrcodegen/Ecc';
+import type { QrSegment } from '@/client/qr/thirdparty/qrcodegen/qrSegment';
+import type { ModuleRegion } from '@/client/qr/decoder/types';
+
+import { QrCode } from '@/client/qr/thirdparty/qrcodegen/qrCode';
+import { functionModuleMap } from '@/client/qr/decoder/functionModules';
+import {
+  deinterleave,
+  extractCodewords,
+  getBlockStructure,
+} from '@/client/qr/decoder/codewords';
+import { rsDecode } from '@/client/qr/decoder/reedSolomon';
+
+// Below this height (in modules) the cutout is no longer legible, so a
+// smaller height is never attempted — the version is bumped instead.
+const MIN_TEXT_HEIGHT_MODULES = 6;
+
+// Once a version yields at least this tall a cutout, stop bumping the
+// version further — anything beyond this is a diminishing-returns trade of
+// a bigger symbol for marginally clearer text.
+const COMFORTABLE_TEXT_HEIGHT_MODULES = 14;
+
+// Radius (in modules) of the clear halo drawn around each glyph's ink,
+// forming the "white border" that keeps the QR noise clear of the text.
+const BORDER_MODULES = 1;
+
+// Fraction of each Reed–Solomon block's correction capacity the cutout is
+// allowed to spend, leaving the remainder as a margin for real-world scan
+// damage (dirt, glare, print defects, perspective distortion, ...).
+const MAX_CAPACITY_FRACTION = 0.7;
+
+// Safety cap on how many versions we'll try before giving up.
+const MAX_VERSION_ATTEMPTS = 20;
+
+export interface CutoutLayout {
+  cells: boolean[][];
+  version: number;
+  margin: number;
+  numCells: number;
+}
+
+interface CutoutSource {
+  qrcode: QrCode;
+  segments: readonly QrSegment[];
+}
+
+// Forces every module inside `interiorClear` light, but only where that
+// module is actually a data/ECC module — finder/timing/alignment/format/
+// version modules are never touched, however large the requested cutout.
+function applyCutout(
+  cells: readonly (readonly boolean[])[],
+  interiorClear: readonly (readonly boolean[])[],
+  fmap: readonly (readonly ModuleRegion[])[],
+  interiorTop: number,
+): boolean[][] {
+  return cells.map((row, y) => {
+    const my = y - interiorTop;
+    const clearRow =
+      my >= 0 && my < interiorClear.length ? interiorClear[my] : null;
+    return row.map((cell, x) =>
+      clearRow && clearRow[x] && fmap[y][x] === 'data' ? false : cell,
+    );
+  });
+}
+
+// Chebyshev (square) dilation, used to grow glyph ink into the surrounding
+// clear border.
+function dilate(
+  mask: readonly (readonly boolean[])[],
+  radius: number,
+): boolean[][] {
+  const height = mask.length;
+  const width = mask[0]?.length ?? 0;
+  const result: boolean[][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => false),
+  );
+  for (const [y, row] of mask.entries()) {
+    for (const [x, isInk] of row.entries()) {
+      if (!isInk) {
+        continue;
+      }
+      for (let dy = -radius; dy <= radius; dy++) {
+        const ny = y + dy;
+        if (ny < 0 || ny >= height) {
+          continue;
+        }
+        for (let dx = -radius; dx <= radius; dx++) {
+          const nx = x + dx;
+          if (nx >= 0 && nx < width) {
+            result[ny][nx] = true;
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+// Rasterises `text` centred in a `width`×`height` module-resolution canvas,
+// returning a boolean ink mask (true = dark/glyph pixel).
+function rasterInkMask(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  font: string,
+  fontSize: number,
+  width: number,
+  height: number,
+): boolean[][] {
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, width, height);
+  ctx.fillStyle = '#000000';
+  ctx.textBaseline = 'alphabetic';
+  ctx.textAlign = 'center';
+  ctx.font = `bold ${fontSize}px "${font}"`;
+
+  const m = ctx.measureText(text);
+  const inkCy =
+    m.actualBoundingBoxAscent > 0
+      ? height / 2 +
+        (m.actualBoundingBoxAscent - m.actualBoundingBoxDescent) / 2
+      : height / 2;
+  ctx.fillText(text, width / 2, inkCy);
+
+  const { data } = ctx.getImageData(0, 0, width, height);
+  const mask: boolean[][] = [];
+  for (let y = 0; y < height; y++) {
+    const row: boolean[] = [];
+    for (let x = 0; x < width; x++) {
+      row.push((data[(y * width + x) * 4] ?? 255) < 128);
+    }
+    mask.push(row);
+  }
+  return mask;
+}
+
+// Runs this project's own QR decoder over the candidate matrix and checks
+// that every Reed–Solomon block both decodes and keeps at least
+// (1 − MAX_CAPACITY_FRACTION) of its correction capacity spare. This is the
+// same check a real scanner's error correction would perform, so it directly
+// answers "would a reader still recover this?" rather than approximating it
+// from module counts.
+function verifyDecodable(
+  clearedCells: readonly (readonly boolean[])[],
+  version: number,
+  mask: number,
+  ecl: Ecc,
+): boolean {
+  const structure = getBlockStructure(version, ecl);
+  const { codewords } = extractCodewords(
+    clearedCells.map((row) => [...row]),
+    version,
+    mask,
+  );
+  const { blocks } = deinterleave(codewords, structure);
+  return blocks.every((block, i) => {
+    const { eccLen } = structure.blocks[i];
+    const result = rsDecode(block, eccLen);
+    if (!result) {
+      return false;
+    }
+    const maxAllowed = Math.floor((eccLen / 2) * MAX_CAPACITY_FRACTION);
+    return result.errorPositions.length <= maxAllowed;
+  });
+}
+
+interface TextFit {
+  clearedCells: boolean[][];
+  height: number;
+}
+
+// Finds the tallest legible cutout that still verifies as decodable with
+// margin at this QR version, or null if even the minimum legible size
+// doesn't leave enough error-correction budget spare.
+function fitTextAtVersion(
+  qrcode: QrCode,
+  rasterText: string,
+  rasterFont: string,
+  ctx: CanvasRenderingContext2D,
+): TextFit | null {
+  const cells = qrcode.getModules();
+  const size = cells.length;
+  const version = qrcode.version;
+  const fmap = functionModuleMap(version);
+
+  const interiorTop = STRUCTURAL_TOP_ROWS;
+  const interiorWidth = size;
+  const interiorHeight = size - STRUCTURAL_TOP_ROWS - STRUCTURAL_BOTTOM_ROWS;
+  const maxTextHeight = interiorHeight - 2 * BORDER_MODULES;
+
+  if (maxTextHeight < MIN_TEXT_HEIGHT_MODULES) {
+    return null;
+  }
+
+  ctx.canvas.width = interiorWidth;
+  ctx.canvas.height = interiorHeight;
+
+  const tryHeight = (targetHeight: number): boolean[][] | null => {
+    const fontSize = fitFontSize(
+      ctx,
+      rasterText,
+      rasterFont,
+      interiorWidth - 2 * BORDER_MODULES,
+      targetHeight,
+    );
+    const inkMask = rasterInkMask(
+      ctx,
+      rasterText,
+      rasterFont,
+      fontSize,
+      interiorWidth,
+      interiorHeight,
+    );
+    const clearMask = dilate(inkMask, BORDER_MODULES);
+    const clearedCells = applyCutout(cells, clearMask, fmap, interiorTop);
+    return verifyDecodable(
+      clearedCells,
+      version,
+      qrcode.mask,
+      qrcode.errorCorrectionLevel,
+    )
+      ? clearMask
+      : null;
+  };
+
+  // The smallest legible size sets the floor: if even that doesn't leave
+  // enough spare capacity, no size at this version will.
+  const minResult = tryHeight(MIN_TEXT_HEIGHT_MODULES);
+  if (!minResult) {
+    return null;
+  }
+
+  let lo = MIN_TEXT_HEIGHT_MODULES;
+  let hi = maxTextHeight;
+  let best = minResult;
+  let bestHeight = MIN_TEXT_HEIGHT_MODULES;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    const candidate = tryHeight(mid);
+    if (candidate) {
+      lo = mid;
+      best = candidate;
+      bestHeight = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  return {
+    clearedCells: applyCutout(cells, best, fmap, interiorTop),
+    height: bestHeight,
+  };
+}
+
+// Tries the cutout at increasing QR versions (re-encoding the same segments
+// and error-correction level each time), since a fixed-size text patch
+// becomes a proportionally smaller — and so more easily correctable —
+// erasure as the symbol grows. Keeps bumping until a comfortably legible
+// height is reached, then uses the tallest layout found across all versions
+// tried (never returning a shorter cutout for a version tried later).
+function fitCutout(
+  baseQrcode: QrCode,
+  segments: readonly QrSegment[],
+  rasterText: string,
+  rasterFont: string,
+): CutoutLayout | null {
+  if (!rasterText) {
+    return null;
+  }
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return null;
+  }
+
+  let qrcode = baseQrcode;
+  let bestLayout: CutoutLayout | null = null;
+  let bestHeight = 0;
+
+  for (let attempt = 0; attempt < MAX_VERSION_ATTEMPTS; attempt++) {
+    const fit = fitTextAtVersion(qrcode, rasterText, rasterFont, ctx);
+    if (fit && fit.height > bestHeight) {
+      bestHeight = fit.height;
+      bestLayout = {
+        cells: fit.clearedCells,
+        version: qrcode.version,
+        margin: SPEC_MARGIN_SIZE,
+        numCells: fit.clearedCells.length + SPEC_MARGIN_SIZE * 2,
+      };
+    }
+
+    if (bestHeight >= COMFORTABLE_TEXT_HEIGHT_MODULES) {
+      break;
+    }
+
+    const nextVersion = qrcode.version + 1;
+    if (nextVersion > QrCode.MAX_VERSION) {
+      break;
+    }
+    // boostEcl: false — keep the level the user asked for exactly, rather
+    // than silently upgrading it now that a bigger version has spare room.
+    qrcode = QrCode.encodeSegments(
+      segments,
+      qrcode.errorCorrectionLevel,
+      nextVersion,
+      nextVersion,
+      -1,
+      false,
+    );
+  }
+
+  return bestLayout;
+}
+
+export function useCutoutLayout(
+  details: CutoutSource,
+  rasterText: string,
+  rasterFont: string,
+): CutoutLayout | null {
+  const [layout, setLayout] = useState<CutoutLayout | null>(null);
+
+  useEffect(() => {
+    if (!rasterText) {
+      return;
+    }
+    let cancelled = false;
+
+    async function run() {
+      await document.fonts.load(`bold 72px "${rasterFont}"`);
+      if (cancelled) {
+        return;
+      }
+      setLayout(
+        fitCutout(details.qrcode, details.segments, rasterText, rasterFont),
+      );
+    }
+
+    run().catch(console.error);
+    return () => {
+      cancelled = true;
+    };
+  }, [details, rasterText, rasterFont]);
+
+  return rasterText ? layout : null;
+}

--- a/src/client/qr/thirdparty/qrcode.react/textCutout.ts
+++ b/src/client/qr/thirdparty/qrcode.react/textCutout.ts
@@ -69,7 +69,15 @@ const LOW_REMAINING_FRACTION = 0.1;
 const MAX_VERSION_ATTEMPTS = 30;
 
 export interface CutoutLayout {
-  version: number;
+  /** The QR code actually encoded and rendered — its own version and error-correction
+   *  level, which the cutout may have chosen independently of the caller's request. */
+  qrcode: QrCode;
+  /** The modules as actually rendered: the surrounding pattern with the text+border's
+   *  clip zone forced light, exactly as a scanner would read them. */
+  cells: boolean[][];
+  /** Same segments the caller encoded — carried through so this can double as a
+   *  QrCodeDetails-shaped source for debug reporting. */
+  segments: readonly QrSegment[];
   margin: number;
   numCells: number;
   /** The surrounding QR pattern, with every module clipping the text+border left light. */
@@ -395,6 +403,7 @@ function fitTextAtVersion(
 // where to draw the real SVG <text> glyph on top of it.
 function buildLayout(
   qrcode: QrCode,
+  segments: readonly QrSegment[],
   fit: TextFit,
   rasterText: string,
   rasterFont: string,
@@ -425,7 +434,9 @@ function buildLayout(
   const baselineY = textBaselineY(ctx, rasterText, interiorHeight);
 
   return {
-    version: qrcode.version,
+    qrcode,
+    cells: clearedCells,
+    segments,
     margin: SPEC_MARGIN_SIZE,
     numCells: size + SPEC_MARGIN_SIZE * 2,
     patternPath: generateFillPath(
@@ -483,7 +494,7 @@ function fitCutout(
       requiredSpare,
     );
     if (fit) {
-      return buildLayout(qrcode, fit, rasterText, rasterFont, ctx);
+      return buildLayout(qrcode, segments, fit, rasterText, rasterFont, ctx);
     }
 
     const nextVersion = qrcode.version + 1;

--- a/src/client/qr/thirdparty/qrcode.react/textCutout.ts
+++ b/src/client/qr/thirdparty/qrcode.react/textCutout.ts
@@ -1,37 +1,35 @@
 /*
- * Implements the 'cutout' dot style: a legible hole shaped like `rasterText`
- * punched into the data modules, with every other module left as a normal
- * full square.
+ * Implements the 'cutout' dot style: `rasterText` drawn as solid black full
+ * modules, with a narrow (half-module) white border separating it from the
+ * surrounding pattern, with every other module left as a normal full
+ * square.
  *
  * Unlike the decorative 'text' style (which only ever redraws the true QR
- * value, just visually dressed up), this style actually forces modules
- * light regardless of their encoded value — a scanner reading those modules
- * sees plain white, exactly like any other reader would. That's only safe
+ * value, just visually dressed up), this style actually overwrites modules
+ * regardless of their encoded value — a scanner reading those modules sees
+ * whatever we drew, exactly like any other reader would. That's only safe
  * because the affected modules are always Reed–Solomon data/ECC modules
  * (never finder/timing/alignment/format/version, which carry no redundancy
  * at all), and because every candidate layout is verified by literally
  * running this project's QR decoder over the resulting matrix before it's
  * accepted — the same simulation a real scan would produce, not a guess
- * about how much can safely be erased.
+ * about how much can safely be overwritten.
  *
- * The cutout must not swallow the error-correction budget the user selected
- * in "Min error correction" — that budget is meant for real-world scan
- * damage, not for a hole the generator put there on purpose. So at least
- * half of the selected level's own nominal correction capacity is always
- * kept spare afterwards (see KEEP_FRACTION), and extra room for a bigger
- * cutout is found "for free" wherever possible first by raising the
- * error-correction level at the same version (more ECC codewords, no
- * bigger symbol), and only then by raising the version.
+ * The style always encodes at high error correction — that's the biggest
+ * error budget the format has — and then re-encodes at successively higher
+ * versions only if even the smallest legible text doesn't leave a low
+ * amount of that budget spare. Text is otherwise sized as large as the
+ * resulting version allows, right up to that low remaining margin.
  */
 
 import { useEffect, useState } from 'react';
 
-import { fitFontSize } from './fontFit';
 import {
   SPEC_MARGIN_SIZE,
   STRUCTURAL_TOP_ROWS,
   STRUCTURAL_BOTTOM_ROWS,
 } from './constants';
+import { fitFontSize } from './fontFit';
 
 import type { QrSegment } from '@/client/qr/thirdparty/qrcodegen/qrSegment';
 import type { ModuleRegion } from '@/client/qr/decoder/types';
@@ -47,54 +45,45 @@ import {
 import { rsDecode } from '@/client/qr/decoder/reedSolomon';
 
 // Below this height (in modules) the cutout is not attempted — a smaller
-// glyph than this is illegible however clean the render, and blocky/heavy
-// display fonts (Impact and friends) tend to blob together at this scale
-// once dilated for the border.
+// glyph than this is illegible however clean the render.
 const MIN_TEXT_HEIGHT_MODULES = 8;
 
-// Once a version/level combination yields at least this tall a cutout, stop
-// searching further — this is comfortably legible for a couple of
-// characters, and anything beyond is a diminishing-returns trade of a
-// bigger symbol for marginally clearer text.
-const COMFORTABLE_TEXT_HEIGHT_MODULES = 20;
+// Radius (in whole modules) of the ring around the text's ink treated as
+// "at risk" for the error-correction budget check. The border actually
+// drawn is only half a module wide (see generateBorderOverlayPath) —
+// checking against a full module is deliberately more pessimistic than
+// what's really overwritten, which only widens the safety margin.
+const RING_RADIUS_MODULES = 1;
 
-// Radius (in modules) of the clear halo drawn around each glyph's ink,
-// forming the "white border" that keeps the QR noise clear of the text.
-const BORDER_MODULES = 1;
+// The error-correction level is always the format's strongest, giving the
+// text and border the biggest possible budget to draw within.
+const LEVEL = Ecc.HIGH;
 
-// However the cutout's cost is funded (see fitCutout's doc comment), at
-// least this fraction of the selected level's own nominal correction
-// capacity must remain spare afterwards — the "small margin" for real-world
-// scan damage (dirt, glare, print defects, perspective distortion, ...)
-// that the cutout must never fully spend.
-const KEEP_FRACTION = 0.5;
-
-// Every level from the user's selection upward is tried (at the same
-// version) before the version itself is bumped, since a higher level costs
-// nothing in symbol size and — because the required spare is always pegged
-// to the *selected* level's own capacity, never the escalated one — funds
-// a bigger cutout without eroding the guaranteed floor any further.
-const LEVELS = [Ecc.LOW, Ecc.MEDIUM, Ecc.QUARTILE, Ecc.HIGH];
+// Only this fraction of the level's own nominal correction capacity needs
+// to remain spare after drawing the text and border — deliberately low, so
+// the text is sized as large as the version allows rather than kept small.
+const LOW_REMAINING_FRACTION = 0.1;
 
 // Safety cap on how many versions we'll try before giving up.
 const MAX_VERSION_ATTEMPTS = 30;
 
 export interface CutoutLayout {
-  cells: boolean[][];
   version: number;
   margin: number;
   numCells: number;
+  /** Full pattern at native module resolution, with the text's ink forced black. */
+  blackPath: string;
+  /** Half-module-wide white border around the text, drawn on top of blackPath. */
+  borderOverlayPath: string;
 }
 
 interface CutoutSource {
-  qrcode: QrCode;
   segments: readonly QrSegment[];
 }
 
 // Total codewords correctable across every Reed–Solomon block at this
 // version/level — a pure function of the standard tables, independent of
-// what's actually encoded, so it can be used as a reference even for a
-// level/version combination nothing has been encoded at.
+// what's actually encoded.
 function totalCorrectableCapacity(version: number, ecl: Ecc): number {
   const structure = getBlockStructure(version, ecl);
   return structure.blocks.reduce(
@@ -103,43 +92,57 @@ function totalCorrectableCapacity(version: number, ecl: Ecc): number {
   );
 }
 
-// Re-encodes `segments` at an exact (version, level), or returns null if the
-// data doesn't fit that combination (never boosts the level or version
-// beyond what's asked, since the caller is deliberately probing a specific
-// combination).
+// Re-encodes `segments` at an exact (version, LEVEL), or returns null if the
+// data doesn't fit (never boosts the level or version beyond what's asked).
 function tryEncode(
   segments: readonly QrSegment[],
-  level: Ecc,
   version: number,
 ): QrCode | null {
   try {
-    return QrCode.encodeSegments(segments, level, version, version, -1, false);
+    return QrCode.encodeSegments(segments, LEVEL, version, version, -1, false);
   } catch {
     return null;
   }
 }
 
-// Forces every module inside `interiorClear` light, but only where that
-// module is actually a data/ECC module — finder/timing/alignment/format/
-// version modules are never touched, however large the requested cutout.
-function applyCutout(
-  cells: readonly (readonly boolean[])[],
-  interiorClear: readonly (readonly boolean[])[],
-  fmap: readonly (readonly ModuleRegion[])[],
-  interiorTop: number,
-): boolean[][] {
-  return cells.map((row, y) => {
-    const my = y - interiorTop;
-    const clearRow =
-      my >= 0 && my < interiorClear.length ? interiorClear[my] : null;
-    return row.map((cell, x) =>
-      clearRow && clearRow[x] && fmap[y][x] === 'data' ? false : cell,
-    );
-  });
+// Generates an SVG fill path for a boolean grid. Grid cell (row, col)
+// occupies the square [offsetX+col*scale, offsetY+row*scale] sized
+// scale×scale — filled cells merge seamlessly at any scale, unlike a
+// stroked outline, which is what lets the border be drawn at a finer
+// (half-module) scale than the text without visible seams between rows.
+function generateFillPath(
+  mask: readonly (readonly boolean[])[],
+  offsetX: number,
+  offsetY: number,
+  scale: number,
+): string {
+  const ops: string[] = [];
+  for (const [row, cells] of mask.entries()) {
+    let start: number | null = null;
+    const emit = (from: number, to: number): void => {
+      const x = offsetX + from * scale;
+      const y = offsetY + row * scale;
+      const w = (to - from) * scale;
+      ops.push(`M${x},${y}h${w}v${scale}H${x}z`);
+    };
+    for (const [col, cell] of cells.entries()) {
+      if (cell && start === null) {
+        start = col;
+      } else if (!cell && start !== null) {
+        emit(start, col);
+        start = null;
+      }
+    }
+    if (start !== null) {
+      emit(start, cells.length);
+    }
+  }
+  return ops.join('');
 }
 
-// Chebyshev (square) dilation, used to grow glyph ink into the surrounding
-// clear border.
+// Chebyshev (square) dilation, used both to build the full-module "at risk"
+// ring for the budget check and, on an upsampled grid, the half-module
+// border ring for rendering.
 function dilate(
   mask: readonly (readonly boolean[])[],
   radius: number,
@@ -150,8 +153,8 @@ function dilate(
     Array.from({ length: width }, () => false),
   );
   for (const [y, row] of mask.entries()) {
-    for (const [x, isInk] of row.entries()) {
-      if (!isInk) {
+    for (const [x, isSet] of row.entries()) {
+      if (!isSet) {
         continue;
       }
       for (let dy = -radius; dy <= radius; dy++) {
@@ -171,10 +174,25 @@ function dilate(
   return result;
 }
 
+// Doubles a module-resolution mask into a 2×2-subcell-per-module grid, so a
+// 1-subcell dilation on the result is exactly a half-module grow.
+function upsample2x(mask: readonly (readonly boolean[])[]): boolean[][] {
+  const result: boolean[][] = [];
+  for (const row of mask) {
+    const r0: boolean[] = [];
+    for (const cell of row) {
+      r0.push(cell, cell);
+    }
+    result.push(r0, [...r0]);
+  }
+  return result;
+}
+
 // Rasterises `text` centred in a `width`×`height` module-resolution canvas,
 // returning a boolean ink mask (true = dark/glyph pixel). Rendered at the
-// font's natural weight (not synthetically bolded) — see fitFontSize's doc
-// for why that matters here specifically.
+// font's natural weight (not synthetically bolded), which keeps already-
+// heavy display fonts (Impact and friends) from blobbing strokes together
+// at this resolution.
 function rasterInkMask(
   ctx: CanvasRenderingContext2D,
   text: string,
@@ -210,21 +228,50 @@ function rasterInkMask(
   return mask;
 }
 
+// Forces every module inside `ink` black and every module inside `ring`
+// (but not already ink) white, except structural modules, which are never
+// touched. Used only for the decodability check — a full module's worth of
+// "at risk" ring, deliberately more pessimistic than the half-module border
+// actually drawn.
+function withInkAndRingForced(
+  cells: readonly (readonly boolean[])[],
+  ink: readonly (readonly boolean[])[],
+  ring: readonly (readonly boolean[])[],
+  fmap: readonly (readonly ModuleRegion[])[],
+  interiorTop: number,
+): boolean[][] {
+  return cells.map((row, y) => {
+    const my = y - interiorTop;
+    const inkRow = my >= 0 && my < ink.length ? ink[my] : null;
+    const ringRow = my >= 0 && my < ring.length ? ring[my] : null;
+    return row.map((cell, x) => {
+      if (fmap[y][x] !== 'data') {
+        return cell;
+      }
+      if (inkRow?.[x]) {
+        return true;
+      }
+      if (ringRow?.[x]) {
+        return false;
+      }
+      return cell;
+    });
+  });
+}
+
 // Runs this project's own QR decoder over the candidate matrix and checks
 // that every Reed–Solomon block decodes, and that the total spare
 // correction capacity left afterwards is at least `requiredSpare` — the
 // same check a real scanner's error correction would perform, so it
-// directly answers "would a reader still recover this, with the selected
-// level's protection intact?" rather than approximating it from module
-// counts.
+// directly answers "would a reader still recover this?" rather than
+// approximating it from module counts.
 function verifyDecodable(
   clearedCells: readonly (readonly boolean[])[],
   version: number,
   mask: number,
-  candidateLevel: Ecc,
   requiredSpare: number,
 ): boolean {
-  const structure = getBlockStructure(version, candidateLevel);
+  const structure = getBlockStructure(version, LEVEL);
   const { codewords } = extractCodewords(
     clearedCells.map((row) => [...row]),
     version,
@@ -245,13 +292,15 @@ function verifyDecodable(
 }
 
 interface TextFit {
-  clearedCells: boolean[][];
+  ink: boolean[][];
+  interiorTop: number;
+  fmap: ModuleRegion[][];
   height: number;
 }
 
-// Finds the tallest legible cutout at this exact (version, level) that still
-// leaves `requiredSpare` correction capacity, or null if even the minimum
-// legible size doesn't.
+// Finds the tallest legible text at this exact version that still leaves
+// `requiredSpare` correction capacity, or null if even the minimum legible
+// size doesn't.
 function fitTextAtVersion(
   qrcode: QrCode,
   rasterText: string,
@@ -267,7 +316,7 @@ function fitTextAtVersion(
   const interiorTop = STRUCTURAL_TOP_ROWS;
   const interiorWidth = size;
   const interiorHeight = size - STRUCTURAL_TOP_ROWS - STRUCTURAL_BOTTOM_ROWS;
-  const maxTextHeight = interiorHeight - 2 * BORDER_MODULES;
+  const maxTextHeight = interiorHeight - 2 * RING_RADIUS_MODULES;
 
   if (maxTextHeight < MIN_TEXT_HEIGHT_MODULES) {
     return null;
@@ -281,11 +330,11 @@ function fitTextAtVersion(
       ctx,
       rasterText,
       rasterFont,
-      interiorWidth - 2 * BORDER_MODULES,
+      interiorWidth - 2 * RING_RADIUS_MODULES,
       targetHeight,
       false,
     );
-    const inkMask = rasterInkMask(
+    const ink = rasterInkMask(
       ctx,
       rasterText,
       rasterFont,
@@ -293,21 +342,23 @@ function fitTextAtVersion(
       interiorWidth,
       interiorHeight,
     );
-    const clearMask = dilate(inkMask, BORDER_MODULES);
-    const clearedCells = applyCutout(cells, clearMask, fmap, interiorTop);
-    return verifyDecodable(
-      clearedCells,
-      version,
-      qrcode.mask,
-      qrcode.errorCorrectionLevel,
-      requiredSpare,
-    )
-      ? clearMask
+    const ring = dilate(ink, RING_RADIUS_MODULES).map((row, y) =>
+      row.map((cell, x) => cell && !ink[y]?.[x]),
+    );
+    const clearedCells = withInkAndRingForced(
+      cells,
+      ink,
+      ring,
+      fmap,
+      interiorTop,
+    );
+    return verifyDecodable(clearedCells, version, qrcode.mask, requiredSpare)
+      ? ink
       : null;
   };
 
   // The smallest legible size sets the floor: if even that doesn't leave
-  // enough spare capacity, no size at this version/level will.
+  // enough spare capacity, no size at this version will.
   const minResult = tryHeight(MIN_TEXT_HEIGHT_MODULES);
   if (!minResult) {
     return null;
@@ -329,27 +380,62 @@ function fitTextAtVersion(
     }
   }
 
-  return {
-    clearedCells: applyCutout(cells, best, fmap, interiorTop),
-    height: bestHeight,
-  };
+  return { ink: best, interiorTop, fmap, height: bestHeight };
 }
 
-// Tries the cutout at the selected error-correction level first, then at
-// each higher level (still at the same version — free extra budget), then
-// bumps the version and repeats, until a comfortably legible height is
-// reached or the version cap is exhausted.
-//
-// Whichever (version, level) combination actually ends up drawn, the
-// requirement checked at every step is the same: at least KEEP_FRACTION of
-// the *selected* level's own nominal correction capacity for that version —
-// never the escalated level's, so escalating only ever funds a bigger
-// cutout, it never lets the guaranteed floor slip. Escalating for free (a
-// higher level at the same version, or more raw codewords at a bigger one)
-// means the cutout increasingly comes out of that extra capacity rather
-// than the user's selected level's own share of it.
+// The text's ink, forced black, at native module resolution — everything
+// else in `cells` (including the border ring) is left exactly as encoded,
+// since the border overlay handles clearing it separately.
+function buildBlackPath(
+  cells: readonly (readonly boolean[])[],
+  fit: TextFit,
+  margin: number,
+): string {
+  const { ink, fmap, interiorTop } = fit;
+  const withInk = cells.map((row, y) => {
+    const my = y - interiorTop;
+    const inkRow = my >= 0 && my < ink.length ? ink[my] : null;
+    return row.map((cell, x) =>
+      inkRow?.[x] && fmap[y][x] === 'data' ? true : cell,
+    );
+  });
+  return generateFillPath(withInk, margin, margin, 1);
+}
+
+// A precise half-module-wide white border: the ink mask grown by exactly
+// one subcell on a 2×-supersampled grid, restricted to data modules. Drawn
+// on top of the black text (which re-covers everything inside the original
+// ink boundary), so only the outer half-module ring stays visible.
+function buildBorderOverlayPath(fit: TextFit, margin: number): string {
+  const { ink, fmap, interiorTop } = fit;
+  const ink2x = upsample2x(ink);
+  // dilate() keeps the original ink subcells set too, so subtract ink2x back
+  // out — the overlay must be only the ring, or it would paint over (and
+  // hide) the black text drawn on top of it.
+  const ring = dilate(ink2x, 1).map((row, sy) =>
+    row.map((isSet, sx) => isSet && !ink2x[sy]?.[sx]),
+  );
+  for (const [sy, row] of ring.entries()) {
+    for (const [sx, isSet] of row.entries()) {
+      if (!isSet) {
+        continue;
+      }
+      const y = Math.floor(sy / 2) + interiorTop;
+      const x = Math.floor(sx / 2);
+      if (fmap[y]?.[x] !== 'data') {
+        row[sx] = false;
+      }
+    }
+  }
+  return generateFillPath(ring, margin, margin + interiorTop, 0.5);
+}
+
+// Always encodes at high error correction, then tries successively higher
+// versions (re-encoding the same segments each time) only until the
+// smallest legible text leaves at least LOW_REMAINING_FRACTION of that
+// version's own correction capacity spare — text is otherwise sized as
+// large as it can be within that low remaining margin.
 function fitCutout(
-  baseQrcode: QrCode,
   segments: readonly QrSegment[],
   rasterText: string,
   rasterFont: string,
@@ -364,57 +450,50 @@ function fitCutout(
     return null;
   }
 
-  const targetLevel = baseQrcode.errorCorrectionLevel;
-  const levelsToTry = LEVELS.slice(targetLevel.ordinal);
+  let qrcode = QrCode.encodeSegments(
+    segments,
+    LEVEL,
+    1,
+    QrCode.MAX_VERSION,
+    -1,
+    false,
+  );
 
-  let bestLayout: CutoutLayout | null = null;
-  let bestHeight = 0;
-
-  for (
-    let version = baseQrcode.version, attempt = 0;
-    attempt < MAX_VERSION_ATTEMPTS;
-    version++, attempt++
-  ) {
+  for (let attempt = 0; attempt < MAX_VERSION_ATTEMPTS; attempt++) {
     const requiredSpare = Math.ceil(
-      totalCorrectableCapacity(version, targetLevel) * KEEP_FRACTION,
+      totalCorrectableCapacity(qrcode.version, LEVEL) * LOW_REMAINING_FRACTION,
     );
 
-    for (const level of levelsToTry) {
-      const qrcode =
-        level.ordinal === targetLevel.ordinal && version === baseQrcode.version
-          ? baseQrcode
-          : tryEncode(segments, level, version);
-      if (!qrcode) {
-        continue;
-      }
-
-      const fit = fitTextAtVersion(
-        qrcode,
-        rasterText,
-        rasterFont,
-        ctx,
-        requiredSpare,
-      );
-      if (fit && fit.height > bestHeight) {
-        bestHeight = fit.height;
-        bestLayout = {
-          cells: fit.clearedCells,
-          version,
-          margin: SPEC_MARGIN_SIZE,
-          numCells: fit.clearedCells.length + SPEC_MARGIN_SIZE * 2,
-        };
-      }
+    const fit = fitTextAtVersion(
+      qrcode,
+      rasterText,
+      rasterFont,
+      ctx,
+      requiredSpare,
+    );
+    if (fit) {
+      const cells = qrcode.getModules();
+      return {
+        version: qrcode.version,
+        margin: SPEC_MARGIN_SIZE,
+        numCells: cells.length + SPEC_MARGIN_SIZE * 2,
+        blackPath: buildBlackPath(cells, fit, SPEC_MARGIN_SIZE),
+        borderOverlayPath: buildBorderOverlayPath(fit, SPEC_MARGIN_SIZE),
+      };
     }
 
-    if (bestHeight >= COMFORTABLE_TEXT_HEIGHT_MODULES) {
-      break;
+    const nextVersion = qrcode.version + 1;
+    if (nextVersion > QrCode.MAX_VERSION) {
+      return null;
     }
-    if (version + 1 > QrCode.MAX_VERSION) {
-      break;
+    const next = tryEncode(segments, nextVersion);
+    if (!next) {
+      return null;
     }
+    qrcode = next;
   }
 
-  return bestLayout;
+  return null;
 }
 
 export function useCutoutLayout(
@@ -435,9 +514,7 @@ export function useCutoutLayout(
       if (cancelled) {
         return;
       }
-      setLayout(
-        fitCutout(details.qrcode, details.segments, rasterText, rasterFont),
-      );
+      setLayout(fitCutout(details.segments, rasterText, rasterFont));
     }
 
     run().catch(console.error);


### PR DESCRIPTION
Adds a new dotStyle, 'cutout', that punches a legible hole shaped like
rasterText (plus a small clear border) into the data modules, leaving
every other module a normal full square. Unlike the existing 'text'
style, which only ever redraws a module's true value, this one really
erases modules — so every candidate layout is verified by running the
project's own QR decoder (functionModuleMap/extractCodewords/
deinterleave/rsDecode) over the resulting matrix, requiring each
Reed–Solomon block to decode with a spare correction margin. The QR
version is bumped automatically when the text can't fit legibly within
that margin, since a fixed-size cutout becomes a proportionally smaller
erasure at higher versions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0141rW5A3JP9AR6hDfPVBmpz